### PR TITLE
swap to array_replace to preserve the array keys.

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -175,7 +175,7 @@ class Api
 
 		$curl_options = $default_curl_options;
 		if(isset($this->curl_options) && is_array($this->curl_options)) {
-			$curl_options = array_merge($default_curl_options, $this->curl_options);
+			$curl_options = array_replace($default_curl_options, $this->curl_options);
 		}
 
 		$headers = array("X-Auth-Email: {$this->email}", "X-Auth-Key: {$this->auth_key}");


### PR DESCRIPTION
I was trying to change the `CURLOPT_TIMEOUT` setting and kept getting extra data with my JSON response whenever I used the `setCurlOption`.