### PR TITLE
[CS] PSR-2 compliance: breaks compatibility (snake case => camel case)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 .ds_store
+.idea

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,28 @@
 {
-    "name": "jamesryanbell/cloudflare",
-    "description": "Cloudflare API V4 PHP wrapper",
-    "license": "MIT",
-    "keywords": ["cloudflare", "api"],
-    "authors": [
-        {
-            "name": "James Bell",
-            "email": "james@james-bell.co.uk"
-        }
-    ],
-    "require": {},
-    "require-dev": {
-        "phpunit/phpunit": "*",
-        "satooshi/php-coveralls": "dev-master"
-    },
-    "autoload": {
-        "psr-4": {
-            "JamesRyanBell\\Cloudflare\\": "src"
-        }
+  "name": "jamesryanbell/cloudflare",
+  "description": "Cloudflare API V4 PHP wrapper",
+  "license": "MIT",
+  "keywords": [
+    "cloudflare",
+    "api"
+  ],
+  "authors": [
+    {
+      "name": "James Bell",
+      "email": "james@james-bell.co.uk"
     }
+  ],
+  "require": {
+    "php": ">=5.4"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "*",
+    "satooshi/php-coveralls": "dev-master"
+  },
+  "autoload": {
+    "psr-4": {
+      "JamesRyanBell\\Cloudflare\\": "src",
+      "JamesRyanBell\\CloudflareTests\\": "tests"
+    }
+  }
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -1,229 +1,261 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare;
-use JamesRyanBell\Cloudflare\User;
 
-use \Exception;
+use Exception;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class Api
 {
-	protected $permission_level = array('read' => null, 'edit' => null);
+    protected $permissionLevel = [
+        'read' => null,
+        'edit' => null,
+    ];
 
-	public $email;
-	public $auth_key;
-	public $curl_options;
-	private $permissions = null;
+    public $email;
+    public $authKey;
+    public $curlOptions;
+    private $permissions = null;
 
-	/**
-	 * Make a new instance of the API client
-	 * This can be done via providing the email address and api key as seperate parameters
-	 * or by passing in an already instantiated object from which the details will be extracted
-	 */
-	public function __construct()
-	{
-		$num_args = func_num_args();
-		if ($num_args === 1)
-		{
-			$parameters         = func_get_args();
-			$client             = $parameters[0];
-			$this->email        = $client->email;
-			$this->auth_key     = $client->auth_key;
-			$this->curl_options = $client->curl_options;
-			$this->permissions  = $client->permissions;
-		} else if ($num_args === 2) {
-			$parameters     = func_get_args();
-			$this->email    = $parameters[0];
-			$this->auth_key = $parameters[1];
-		}
-	}
+    /**
+     * Make a new instance of the API client.
+     *
+     * This can be done via providing the email address and api key as separate parameters
+     * or by passing in an already instantiated object from which the details will be extracted
+     */
+    public function __construct()
+    {
+        $num_args = func_num_args();
+        if ($num_args === 1) {
+            $parameters = func_get_args();
+            $client = $parameters[0];
+            $this->email = $client->email;
+            $this->authKey = $client->authKey;
+            $this->curlOptions = $client->curlOptions;
+            $this->permissions = $client->permissions;
+        } elseif ($num_args === 2) {
+            $parameters = func_get_args();
+            $this->email = $parameters[0];
+            $this->authKey = $parameters[1];
+        }
+    }
 
-	/**
-	 * Setter to allow the setting of the email address
-	 * @param string $email The email address associated with the Cloudflare account
-	 */
-	public function setEmail($email)
-	{
-		$this->email = $email;
-	}
+    /**
+     * Setter to allow the setting of the email address.
+     *
+     * @param string $email The email address associated with the Cloudflare account
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
 
-	/**
-	 * Setter to allow the setting of the Authentication Key
-	 * @param string $token Authentication key, this can be retrieve from the 'My Account' section of the Cloudflare account
-	 */
-	public function setAuthKey($token)
-	{
-		$this->auth_key = $token;
-	}
+    /**
+     * Setter to allow the setting of the Authentication Key.
+     *
+     * @param string $token Authentication key, can be retrieve from the 'My Account' section of the Cloudflare account
+     */
+    public function setAuthKey($token)
+    {
+        $this->authKey = $token;
+    }
 
-	/**
-	 * Setter to allow the adding / changing of the Curl options that will be used within the HTTP requests
-	 * @param long $key    The CURLOPT_XXX option to set e.g. CURLOPT_TIMEOUT
-	 * @param mixed $value The value to be set on option e.g. 10
-	 */
-	public function setCurlOption($key, $value) {
-		$this->curl_options[$key] = $value;
-	}
+    /**
+     * Setter to allow the adding / changing of the Curl options that will be used within the HTTP requests.
+     *
+     * @param long  $key   The CURLOPT_XXX option to set e.g. CURLOPT_TIMEOUT
+     * @param mixed $value The value to be set on option e.g. 10
+     */
+    public function setCurlOption($key, $value)
+    {
+        $this->curlOptions[$key] = $value;
+    }
 
-	/**
-	 * API call method for sending requests using GET
-	 * @param string $path Path of the endpoint
-	 * @param array  $data Data to be sent along with the request
-	 */
-	public function get($path, $data = array())
-	{
-		return $this->request($path, $data, 'get', 'read');
-	}
+    /**
+     * API call method for sending requests using GET.
+     *
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
+     *
+     * @return array|mixed
+     */
+    public function get($path, array $data = [])
+    {
+        return $this->request($path, $data, 'get', 'read');
+    }
 
-	/**
-	 * API call method for sending requests using POST
-	 * @param string $path Path of the endpoint
-	 * @param array  $data Data to be sent along with the request
-	 */
-	public function post($path, $data = array())
-	{
-		return $this->request($path, $data, 'post', 'edit');
-	}
+    /**
+     * API call method for sending requests using POST.
+     *
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
+     *
+     * @return array|mixed
+     */
+    public function post($path, array $data = [])
+    {
+        return $this->request($path, $data, 'post', 'edit');
+    }
 
-	/**
-	 * API call method for sending requests using PUT
-	 * @param string $path Path of the endpoint
-	 * @param array  $data Data to be sent along with the request
-	 */
-	public function put($path, $data = array())
-	{
-		return $this->request($path, $data, 'put', 'edit');
-	}
+    /**
+     * API call method for sending requests using PUT.
+     *
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
+     *
+     * @return array|mixed
+     */
+    public function put($path, array $data = [])
+    {
+        return $this->request($path, $data, 'put', 'edit');
+    }
 
-	/**
-	 * API call method for sending requests using DELETE
-	 * @param string $path Path of the endpoint
-	 * @param array  $data Data to be sent along with the request
-	 */
-	public function delete($path, $data = array())
-	{
-		return $this->request($path, $data, 'delete', 'edit');
-	}
+    /**
+     * API call method for sending requests using DELETE.
+     *
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
+     *
+     * @return array|mixed
+     */
+    public function delete($path, array $data = [])
+    {
+        return $this->request($path, $data, 'delete', 'edit');
+    }
 
-	/**
-	 * API call method for sending requests using PATCH
-	 * @param string $path Path of the endpoint
-	 * @param array  $data Data to be sent along with the request
-	 */
-	public function patch($path, $data = array())
-	{
-		return $this->request($path, $data, 'patch', 'edit');
-	}
+    /**
+     * API call method for sending requests using PATCH.
+     *
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
+     *
+     * @return array|mixed
+     */
+    public function patch($path, array $data = [])
+    {
+        return $this->request($path, $data, 'patch', 'edit');
+    }
 
-	public function _permissions() {
-		if(!$this->permissions) {
-			$api = new User($this->email, $this->auth_key);
-			$user = $api->user();
-			$this->permissions = $user->result->organizations[0]->permissions;
-		}
-		return $this->permissions;
-	}
+    /**
+     * Fetch permissions from API and set them in the object.
+     *
+     * @return mixed|null Permissions
+     */
+    public function setPermissions()
+    {
+        if (!$this->permissions) {
+            $api = new User($this->email, $this->authKey);
+            $user = $api->user();
+            $this->permissions = $user->result->organizations[0]->permissions;
+        }
 
-	/**
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * API call method for sending requests using GET, POST, PUT, DELETE OR PATCH
-	 * @param string $path             Path of the endpoint
-	 * @param array  $data             Data to be sent along with the request
-	 * @param string $method           Type of method that should be used ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')
-	 * @param string $permission_level Permission level required to preform the action
-	 */
-	protected function request($path, $data = array(), $method = 'get', $permission_level = 'read')
-	{
-		if( !isset($this->email) || !isset($this->auth_key) ) {
-			throw new Exception('Authentication information must be provided');
-			return false;
-		}
+        return $this->permissions;
+    }
 
-		if( !is_null($this->permission_level[$permission_level]) ) {
-			if( !$this->permissions ) { $this->_permissions(); }
-			if( !isset($this->permissions) || !in_array($this->permission_level[$permission_level], $this->permissions) ) {
-				throw new Exception('You do not have permission to perform this request');
-				return false;
-			}
-		}
+    /**
+     * API call method for sending requests using GET, POST, PUT, DELETE OR PATCH.
+     *
+     * @param string $path            Path of the endpoint
+     * @param array  $data            Data to be sent along with the request
+     * @param string $method          Type of method that should be used ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')
+     * @param string $permissionLevel Permission level required to preform the action
+     *
+     * @return array|mixed
+     *
+     * @throws Exception
+     *
+     * @codeCoverageIgnore
+     */
+    protected function request($path, array $data = [], $method = 'get', $permissionLevel = 'read')
+    {
+        if (!isset($this->email) || !isset($this->authKey)) {
+            throw new Exception('Authentication information must be provided');
+        }
 
-		//Removes null entries
-		$data = array_filter($data, function($val) {
-			return !is_null($val);
-		});
+        if (!is_null($this->permissionLevel[$permissionLevel])) {
+            if (!$this->permissions) {
+                $this->setPermissions();
+            }
+            if (!isset($this->permissions) || !in_array($this->permissionLevel[$permissionLevel], $this->permissions)) {
+                throw new Exception('You do not have permission to perform this request');
+            }
+        }
 
-		$url = 'https://api.cloudflare.com/client/v4/' . $path;
+        //Removes null entries
+        $data = array_filter($data, function ($val) {
+            return !is_null($val);
+        });
 
-		$default_curl_options = array(
-			CURLOPT_VERBOSE        => false,
-			CURLOPT_FORBID_REUSE   => true,
-			CURLOPT_RETURNTRANSFER => 1,
-			CURLOPT_HEADER         => false,
-			CURLOPT_TIMEOUT        => 5,
-			CURLOPT_SSL_VERIFYPEER => false,
-			CURLOPT_FOLLOWLOCATION => true
-		);
+        $url = 'https://api.cloudflare.com/client/v4/'.$path;
 
-		$curl_options = $default_curl_options;
-		if(isset($this->curl_options) && is_array($this->curl_options)) {
-			$curl_options = array_replace($default_curl_options, $this->curl_options);
-		}
+        $default_curl_options = [
+            CURLOPT_VERBOSE => false,
+            CURLOPT_FORBID_REUSE => true,
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_HEADER => false,
+            CURLOPT_TIMEOUT => 5,
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_FOLLOWLOCATION => true,
+        ];
 
-		$headers = array("X-Auth-Email: {$this->email}", "X-Auth-Key: {$this->auth_key}");
+        $curl_options = $default_curl_options;
+        if (isset($this->curlOptions) && is_array($this->curlOptions)) {
+            $curl_options = array_replace($default_curl_options, $this->curlOptions);
+        }
 
-		$ch = curl_init();
+        $headers = ["X-Auth-Email: {$this->email}", "X-Auth-Key: {$this->authKey}"];
 
-		curl_setopt_array($ch, $curl_options);
+        $ch = curl_init();
 
-		if( $method === 'post' ) {
-			curl_setopt($ch, CURLOPT_POST, true);
-			//curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
-			curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
-		} else if ( $method === 'put' ) {
-			curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
-			curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
-			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
-			//curl_setopt($ch, CURLOPT_HTTPHEADER, array('X-HTTP-Method-Override: PUT'));
-		} else if ( $method === 'delete' ) {
-			curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
-			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
-			$headers[] = "Content-type: application/json";
-		} else if ($method === 'patch') {
-			curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
-			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PATCH");
-			$headers[] = "Content-type: application/json";
-		} else {
-			$url .= '?' . http_build_query($data);
-		}
+        curl_setopt_array($ch, $curl_options);
 
-		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-		curl_setopt($ch, CURLOPT_URL, $url);
+        if ($method === 'post') {
+            curl_setopt($ch, CURLOPT_POST, true);
+            //curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+        } elseif ($method === 'put') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+            //curl_setopt($ch, CURLOPT_HTTPHEADER, array('X-HTTP-Method-Override: PUT'));
+        } elseif ($method === 'delete') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+            $headers[] = 'Content-type: application/json';
+        } elseif ($method === 'patch') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
+            $headers[] = 'Content-type: application/json';
+        } else {
+            $url .= '?'.http_build_query($data);
+        }
 
-		$http_result = curl_exec($ch);
-		$error       = curl_error($ch);
-		$information = curl_getinfo($ch);
-		$http_code   = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_URL, $url);
 
-		curl_close($ch);
-		if ($http_code != 200) {
-			return array(
-				'error'       => $error,
-				'http_code'   => $http_code,
-				'method'      => $method,
-				'result'      => $http_result,
-				'information' => $information
-			);
-		} else {
-			return json_decode($http_result);
-		}
-	}
+        $http_result = curl_exec($ch);
+        $error = curl_error($ch);
+        $information = curl_getinfo($ch);
+        $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        curl_close($ch);
+        if ($http_code != 200) {
+            return [
+                'error' => $error,
+                'http_code' => $http_code,
+                'method' => $method,
+                'result' => $http_result,
+                'information' => $information,
+            ];
+        }
+
+        return json_decode($http_result);
+    }
 }

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -1,128 +1,164 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare;
-use JamesRyanBell\Cloudflare\Api;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * User
  * The currently logged in/authenticated User
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class User extends Api
 {
-	protected $permission_level = array('read' => null, 'edit' => null);
+    protected $permissionLevel = [
+        'read' => null,
+        'edit' => null,
+    ];
 
-	/**
-	 * User details
-	 */
-	public function user()
-	{
-		return $this->get('user');
-	}
+    /**
+     * User details.
+     */
+    public function user()
+    {
+        return $this->get('user');
+    }
 
-	/**
-	 * Update part of your user details
-	 * @param string $first_name User's first name
-	 * @param string $last_name  User's last name
-	 * @param string $telephone  User's telephone number
-	 * @param string $country    The country in which the user lives. (Full list is here: http://en.wikipedia.org/wiki/List_of_country_calling_codes)
-	 * @param string $zipcode    The zipcode or postal code where the user lives.
-	 */
-	public function update($first_name = null, $last_name = null, $telephone = null, $country = null, $zipcode = null)
-	{
-		$data = array(
-			'first_name' => $first_name,
-			'last_name'  => $last_name,
-			'telephone'  => $telephone,
-			'country'    => $country,
-			'zipcode'    => $zipcode
-		);
-		return $this->patch('user', $data);
-	}
+    /**
+     * Update part of your user details.
+     *
+     * @param string $firstName User's first name
+     * @param string $lastName  User's last name
+     * @param string $telephone User's telephone number
+     * @param string $country   The country in which the user lives.
+     *                          (Full list is here: http://en.wikipedia.org/wiki/List_of_country_calling_codes)
+     * @param string $zipcode   The zipcode or postal code where the user lives.
+     *
+     * @return array|mixed
+     */
+    public function update($firstName = null, $lastName = null, $telephone = null, $country = null, $zipcode = null)
+    {
+        $data = [
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'telephone' => $telephone,
+            'country' => $country,
+            'zipcode' => $zipcode,
+        ];
 
-	/**
-	 * Change your email address. Note: You must provide your current password.
-	 * @param string $email         Your contact email address
-	 * @param string $email_confirm Your contact email address, repeated
-	 * @param string $password      Your current password
-	 */
-	public function change_email($email, $email_confirm, $password) {
-		$data = array(
-			'email'         => $email,
-			'confirm_email' => $confirm_email,
-			'password'      => $password
-		);
-		return $this->put('user/email', $data);
-	}
+        return $this->patch('user', $data);
+    }
 
-	/**
-	 * Change your password
-	 * @param string $old_password         Your current password
-	 * @param string $new_password         Your new password
-	 * @param string $new_password_confirm Your new password, repeated
-	 */
-	public function change_password($old_password, $new_password, $new_password_confirm) {
-		$data = array(
-			'old_password'         => $old_password,
-			'new_password'         => $new_password,
-			'new_password_confirm' => $new_password_confirm
-		);
-		return $this->put('user/password', $data);
-	}
+    /**
+     * Change your email address. Note: You must provide your current password.
+     *
+     * @param string $email        Your contact email address
+     * @param string $emailConfirm Your contact email address, repeated
+     * @param string $password     Your current password
+     *
+     * @return array|mixed
+     */
+    public function changeEmail($email, $emailConfirm, $password)
+    {
+        $data = [
+            'email' => $email,
+            'confirm_email' => $emailConfirm,
+            'password' => $password,
+        ];
 
-	/**
-	 * Change your username. Note: You must provide your current password.
-	 * @param string $username A username used to access other cloudflare services, like support
-	 * @param string $password Your current password
-	 */
-	public function change_username($username, $password) {
-		$data = array(
-			'username' => $username,
-			'password' => $password
-		);
-		return $this->put('user/username', $data);
-	}
+        return $this->put('user/email', $data);
+    }
 
-	/**
-	 * Begin setting up CloudFlare two-factor authentication with a given telephone number
-	 * @param int $country_code           The country code of your mobile phone number
-	 * @param string $mobile_phone_number Your mobile phone number
-	 * @param string $current_password    Your current CloudFlare password
-	 */
-	public function initialize_two_factor_authentication($country_code, $mobile_phone_number, $current_password) {
-		$data = array(
-			'country_code'        => $country_code,
-			'mobile_phone_number' => $mobile_phone_number,
-			'current_password'    => $current_password
-		);
-		return $this->post('/user/two_factor_authentication', $data);
-	}
+    /**
+     * Change your password.
+     *
+     * @param string $oldPassword        Your current password
+     * @param string $newPassword        Your new password
+     * @param string $newPasswordConfirm Your new password, repeated
+     *
+     * @return array|mixed
+     */
+    public function changePassword($oldPassword, $newPassword, $newPasswordConfirm)
+    {
+        $data = [
+            'old_password' => $oldPassword,
+            'new_password' => $newPassword,
+            'new_password_confirm' => $newPasswordConfirm,
+        ];
 
-	/**
-	 * Finish setting up CloudFlare two-factor authentication with a given telephone number
-	 * @param int $auth_token The token provided by the two-factor authenticator
-	 */
-	public function finalize_two_factor_authentication($auth_token) {
-		$data = array(
-			'auth_token' => $auth_token
-		);
-		return $this->put('user/two_factor_authentication', $data);
-	}
+        return $this->put('user/password', $data);
+    }
 
-	/**
-	 * Disable two-factor authentication for your CloudFlare user account
-	 * @param int The token provided by the two-factor authenticator
-	 */
-	public function disable_two_factor_authentication($auth_token) {
-		$data = array(
-			'auth_token' => $auth_token
-		);
-		return $this->delete('user/two_factor_authentication', $data);
-	}
+    /**
+     * Change your username. Note: You must provide your current password.
+     *
+     * @param string $username A username used to access other cloudflare services, like support
+     * @param string $password Your current password
+     *
+     * @return array|mixed
+     */
+    public function changeUsername($username, $password)
+    {
+        $data = [
+            'username' => $username,
+            'password' => $password,
+        ];
 
+        return $this->put('user/username', $data);
+    }
+
+    /**
+     * Begin setting up CloudFlare two-factor authentication with a given telephone number.
+     *
+     * @param int    $countryCode       The country code of your mobile phone number
+     * @param string $mobilePhoneNumber Your mobile phone number
+     * @param string $currentPassword   Your current CloudFlare password
+     *
+     * @return array|mixed
+     */
+    public function initializeTwoFactorAuthentication($countryCode, $mobilePhoneNumber, $currentPassword)
+    {
+        $data = [
+            'country_code' => $countryCode,
+            'mobile_phone_number' => $mobilePhoneNumber,
+            'current_password' => $currentPassword,
+        ];
+
+        return $this->post('/user/two_factor_authentication', $data);
+    }
+
+    /**
+     * Finish setting up CloudFlare two-factor authentication with a given telephone number.
+     *
+     * @param int $authToken The token provided by the two-factor authenticator
+     *
+     * @return array|mixed
+     */
+    public function finalizeTwoFactorAuthentication($authToken)
+    {
+        $data = [
+            'auth_token' => $authToken,
+        ];
+
+        return $this->put('user/two_factor_authentication', $data);
+    }
+
+    /**
+     * Disable two-factor authentication for your CloudFlare user account.
+     *
+     * @param int $authToken The token provided by the two-factor authenticator
+     *
+     * @return array|mixed
+     */
+    public function disableTwoFactorAuthentication($authToken)
+    {
+        $data = [
+            'auth_token' => $authToken,
+        ];
+
+        return $this->delete('user/two_factor_authentication', $data);
+    }
 }

--- a/src/Zone/Cache/Cache.php
+++ b/src/Zone/Cache/Cache.php
@@ -1,51 +1,62 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare\Zone;
-use JamesRyanBell\Cloudflare\Api;
+
 use JamesRyanBell\Cloudflare\Zone;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * Cache
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class Cache extends Zone
 {
-	protected $permission_level = array('read' => '#zone:read', 'edit' => '#zone:edit');
+    protected $permissionLevel = [
+        'read' => '#zone:read',
+        'edit' => '#zone:edit',
+    ];
 
-	/**
-	 * Purge all files (permission needed: #zone:edit)
-	 * Remove ALL files from CloudFlare's cache
-	 * @param string  $identifier API item identifier tag
-	 * @param boolean A flag that indicates all resources in CloudFlare's cache should be removed.
-	 *                 Note: This may have dramatic affects on your origin server load after
-	 *                 performing this action. (true)
-	 */
-	public function purge($identifier, $purge_everything = true)
-	{
-		$data = array(
-			'purge_everything' => $purge_everything
-		);
-		return $this->delete('zones/' . $identifier . '/purge_cache', $data);
-	}
+    /**
+     * Purge all files (permission needed: #zone:edit).
+     *
+     * Remove ALL files from CloudFlare's cache
+     *
+     * @param string $identifier      API item identifier tag
+     * @param bool   $purgeEverything A flag that indicates all resources in CloudFlare's cache should be removed.
+     *                                Note: This may have dramatic affects on your origin server load after
+     *                                performing this action. (true)
+     *
+     * @return array|mixed
+     */
+    public function purge($identifier, bool $purgeEverything = true)
+    {
+        $data = [
+            'purgeEverything' => $purgeEverything,
+        ];
 
-	/**
-	 * Purge individual files (permission needed: #zone:edit)
-	 * Remove one or more files from CloudFlare's cache
-	 * @param string $identifier API item identifier tag
-	 * @param array  $files      An array of URLs that should be removed from cache
-	 */
-	public function purge_files($identifier, array $files)
-	{
-		$data = array(
-			'files' => $files
-		);
-		return $this->delete('zones/' . $identifier . '/purge_cache', $data);
-	}
+        return $this->delete('zones/'.$identifier.'/purge_cache', $data);
+    }
 
+    /**
+     * Purge individual files (permission needed: #zone:edit).
+     *
+     * Remove one or more files from CloudFlare's cache
+     *
+     * @param string $identifier API item identifier tag
+     * @param array  $files      An array of URLs that should be removed from cache
+     *
+     * @return array|mixed
+     */
+    public function purgeFiles($identifier, array $files)
+    {
+        $data = [
+            'files' => $files,
+        ];
 
+        return $this->delete('zones/'.$identifier.'/purge_cache', $data);
+    }
 }

--- a/src/Zone/CustomPages/CustomPages.php
+++ b/src/Zone/CustomPages/CustomPages.php
@@ -1,55 +1,67 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare\Zone;
-use JamesRyanBell\Cloudflare\Api;
+
 use JamesRyanBell\Cloudflare\Zone;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * Custom Pages for a Zone
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class CustomPages extends Zone
 {
-	protected $permission_level = array('read' => '#zone_settings:read', 'edit' => '#zone_settings:edit');
+    protected $permissionLevel = [
+        'read' => '#zone_settings:read',
+        'edit' => '#zone_settings:edit',
+    ];
 
-	/**
-	 * Available Custom Pages (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function custom_pages($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/custom_pages');
-	}
+    /**
+     * Available Custom Pages (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function customPages($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/custom_pages');
+    }
 
-	/**
-	 * Custom Page details (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 */
-	public function details($zone_identifier, $identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/custom_pages/' . $identifier);
-	}
+    /**
+     * Custom Page details (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     *
+     * @return array|mixed
+     */
+    public function details($zoneIdentifier, $identifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/custom_pages/'.$identifier);
+    }
 
-	/**
-	 * Update Custom page URL (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 * @param string $url             A URL that is associated with the Custom Page.
-	 * @param string $state           The Custom Page state
-	 */
-	public function update($zone_identifier, $identifier, $url, $state)
-	{
-		$data = array(
-			'url'   => $url,
-			'state' => $state
-		);
-		return $this->patch('zones/' . $zone_identifier . '/custom_pages/' . $identifier, $data);
-	}
+    /**
+     * Update Custom page URL (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     * @param string $url            A URL that is associated with the Custom Page.
+     * @param string $state          The Custom Page state
+     *
+     * @return array|mixed
+     */
+    public function update($zoneIdentifier, $identifier, $url, $state)
+    {
+        $data = [
+            'url' => $url,
+            'state' => $state,
+        ];
 
+        return $this->patch('zones/'.$zoneIdentifier.'/custom_pages/'.$identifier, $data);
+    }
 }

--- a/src/Zone/Dns/Dns.php
+++ b/src/Zone/Dns/Dns.php
@@ -1,102 +1,130 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare\Zone;
-use JamesRyanBell\Cloudflare\Api;
+
 use JamesRyanBell\Cloudflare\Zone;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * DNS Record
  * CloudFlare DNS records
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class Dns extends Zone
 {
-	protected $permission_level = array('read' => '#dns_records:read', 'edit' => '#dns_records:edit');
+    protected $permissionLevel = [
+        'read' => '#dns_records:read',
+        'edit' => '#dns_records:edit',
+    ];
 
-	/**
-	 * Create DNS record (permission needed: #dns_records:edit)
-	 * @param string  $zone_identifier
-	 * @param string  $type    DNS record type (A, AAAA, CNAME, TXT, SRV, LOC, MX, NS, SPF)
-	 * @param string  $name    DNS record name
-	 * @param string  $content DNS record content
-	 * @param integer $ttl     Time to live for DNS record. Value of 1 is 'automatic'
-	 */
-	public function create($zone_identifier, $type, $name, $content, $ttl = 1)
-	{
-		$data = array(
-			'type'    => strtoupper($type),
-			'name'    => $name,
-			'content' => $content,
-			'ttl'     => $ttl
-		);
+    /**
+     * Create DNS record (permission needed: #dns_records:edit).
+     *
+     * @param string $zoneIdentifier
+     * @param string $type           DNS record type (A, AAAA, CNAME, TXT, SRV, LOC, MX, NS, SPF)
+     * @param string $name           DNS record name
+     * @param string $content        DNS record content
+     * @param int    $ttl            Time to live for DNS record. Value of 1 is 'automatic'
+     *
+     * @return array|mixed
+     */
+    public function create($zoneIdentifier, $type, $name, $content, $ttl = 1)
+    {
+        $data = [
+            'type' => strtoupper($type),
+            'name' => $name,
+            'content' => $content,
+            'ttl' => $ttl,
+        ];
 
-		return $this->post('zones/' . $zone_identifier . '/dns_records', $data);
-	}
+        return $this->post('zones/'.$zoneIdentifier.'/dns_records', $data);
+    }
 
-	/**
-	 * List DNS Records (permission needed: #dns_records:read)
-	 * List, search, sort, and filter a zones' DNS records.
-	 * @param string  $zone_identifier
-	 * @param string  $type                      DNS record type (A, AAAA, CNAME, TXT, SRV, LOC, MX, NS, SPF)
-	 * @param string  $name                      DNS record name
-	 * @param string  $content                   DNS record content
-	 * @param string  $vanity_name_server_record Flag for records that were created for the vanity name server feature (true, false)
-	 * @param integer $page                      Page number of paginated results
-	 * @param integer $per_page                  Number of DNS records per page
-	 * @param string  $order                     Field to order records by (type, name, content, ttl, proxied)
-	 * @param string  $direction                 Direction to order domains (asc, desc)
-	 * @param string  $match                     Whether to match all search requirements or at least one (any) (any, all)
-	 */
-	public function list_records($zone_identifier, $type = 'A', $name = null, $content = null, $vanity_name_server_record = null, $page = 1, $per_page = 20, $order = '', $direction = 'desc', $match = 'all')
-	{
-		$data = array(
-			'type'                      => $type,
-			'name'                      => $name,
-			'content'                   => $content,
-			'vanity_name_server_record' => $vanity_name_server_record,
-			'page'                      => $page,
-			'per_page'                  => $per_page,
-			'order'                     => $order,
-			'direction'                 => $direction,
-			'match'                     => $match
-		);
+    /**
+     * List DNS Records (permission needed: #dns_records:read).
+     *
+     * List, search, sort, and filter a zones' DNS records.
+     *
+     * @param string $zoneIdentifier
+     * @param string $type                   DNS record type (A, AAAA, CNAME, TXT, SRV, LOC, MX, NS, SPF)
+     * @param string $name                   DNS record name
+     * @param string $content                DNS record content
+     * @param string $vanityNameServerRecord Flag for records created for the vanity name server feature (true, false)
+     * @param int    $page                   Page number of paginated results
+     * @param int    $perPage                Number of DNS records per page
+     * @param string $order                  Field to order records by (type, name, content, ttl, proxied)
+     * @param string $direction              Direction to order domains (asc, desc)
+     * @param string $match                  Whether to match all search requirements or at least one (any) (any, all)
+     *
+     * @return array|mixed
+     */
+    public function listRecords(
+        $zoneIdentifier,
+        $type = 'A',
+        $name = null,
+        $content = null,
+        $vanityNameServerRecord = null,
+        $page = 1,
+        $perPage = 20,
+        $order = '',
+        $direction = 'desc',
+        $match = 'all'
+    ) {
+        $data = [
+            'type' => $type,
+            'name' => $name,
+            'content' => $content,
+            'vanity_name_server_record' => $vanityNameServerRecord,
+            'page' => $page,
+            'per_page' => $perPage,
+            'order' => $order,
+            'direction' => $direction,
+            'match' => $match,
+        ];
 
-		return $this->get('zones/' . $zone_identifier . '/dns_records', $data);
-	}
+        return $this->get('zones/'.$zoneIdentifier.'/dns_records', $data);
+    }
 
-	/**
-	 * DNS record details (permission needed: #dns_records:read)
-	 * @param string $zone_identifier
-	 * @param string $identifier      API item identifier tag
-	 */
-	public function details($zone_identifier, $identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/dns_records/' . $identifier);
-	}
+    /**
+     * DNS record details (permission needed: #dns_records:read).
+     *
+     * @param string $zoneIdentifier
+     * @param string $identifier     API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function details($zoneIdentifier, $identifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/dns_records/'.$identifier);
+    }
 
-	/**
-	 * Update DNS record (permission needed: #dns_records:edit)
-	 * @param string $zone_identifier
-	 * @param string $identifier      API item identifier tag
-	 */
-	public function update($zone_identifier, $identifier)
-	{
-		return $this->put('zones/' . $zone_identifier . '/dns_records/' . $identifier);
-	}
+    /**
+     * Update DNS record (permission needed: #dns_records:edit).
+     *
+     * @param string $zoneIdentifier
+     * @param string $identifier     API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function update($zoneIdentifier, $identifier)
+    {
+        return $this->put('zones/'.$zoneIdentifier.'/dns_records/'.$identifier);
+    }
 
-	/**
-	 * Update DNS record (permission needed: #dns_records:edit)
-	 * @param string $zone_identifier
-	 * @param string $identifier      API item identifier tag
-	 */
-	public function delete_record($zone_identifier, $identifier)
-	{
-		return $this->delete('zones/' . $zone_identifier . '/dns_records/' . $identifier);
-	}
-
+    /**
+     * Update DNS record (permission needed: #dns_records:edit).
+     *
+     * @param string $zoneIdentifier
+     * @param string $identifier     API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function deleteRecord($zoneIdentifier, $identifier)
+    {
+        return $this->delete('zones/'.$zoneIdentifier.'/dns_records/'.$identifier);
+    }
 }

--- a/src/Zone/KeylessSSL/KeylessSSL.php
+++ b/src/Zone/KeylessSSL/KeylessSSL.php
@@ -1,89 +1,108 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare\Zone;
-use JamesRyanBell\Cloudflare\Api;
+
 use JamesRyanBell\Cloudflare\Zone;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * Keyless SSL for a Zone
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class KeylessSSL extends Zone
 {
-	protected $permission_level = array('read' => '#ssl:read', 'edit' => '#ssl:edit');
+    protected $permissionLevel = [
+        'read' => '#ssl:read',
+        'edit' => '#ssl:edit',
+    ];
 
-	/**
-	 * List Keyless SSLs (permission needed: #ssl:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function certificates($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/keyless_certificates');
-	}
+    /**
+     * List Keyless SSLs (permission needed: #ssl:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function certificates($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/keyless_certificates');
+    }
 
-	/**
-	 * Keyless SSL details (permission needed: #ssl:read)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 */
-	public function details($zone_identifier, $identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/keyless_certificates/' . $identifier);
-	}
+    /**
+     * Keyless SSL details (permission needed: #ssl:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     *
+     * @return array|mixed
+     */
+    public function details($zoneIdentifier, $identifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/keyless_certificates/'.$identifier);
+    }
 
-	/**
-	 * Create a Keyless SSL configuration (permission needed: #ssl:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $certificate     The zone's SSL certificate or certificate and the intermediate(s)
-	 * @param string $host            The keyless SSL hostname
-	 * @param int    $port            The keyless SSL port used to commmunicate between CloudFlare and the client's Keyless SSL server
-	 * @param string $name            The keyless SSL name
-	 * @param string $certificate     The zone's SSL certificate or SSL certificate and intermediate(s)
-	 */
-	public function create($zone_identifier, $host, $port, $name, $certificate)
-	{
-		$data = array(
-			'host'        => $host,
-			'port'        => $port,
-			'name'        => $name,
-			'certificate' => $certificate
-		);
-		return $this->post('zones/' . $zone_identifier . '/keyless_certificates', $data);
-	}
+    /**
+     * Create a Keyless SSL configuration (permission needed: #ssl:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $certificate    The zone's SSL certificate or certificate and the intermediate(s)
+     * @param string $host           The keyless SSL hostname
+     * @param int    $port           The keyless SSL port used for CloudFlare <=> client's Keyless SSL server comm
+     * @param string $name           The keyless SSL name
+     * @param string $certificate    The zone's SSL certificate or SSL certificate and intermediate(s)
+     *
+     * @return array|mixed
+     */
+    public function create($zoneIdentifier, $host, $port, $name, $certificate)
+    {
+        $data = [
+            'host' => $host,
+            'port' => $port,
+            'name' => $name,
+            'certificate' => $certificate,
+        ];
 
-	/**
-	 * Update SSL configuration (permission needed: #ssl:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 * @param string $host            The keyless SSL hostname
-	 * @param string $name            The keyless SSL name
-	 * @param int    $port            The keyless SSL port used to commmunicate between CloudFlare and the client's Keyless SSL server
-	 * @param bool   $enabled         Whether or not the Keyless SSL is on or off
-	 */
-	public function update($zone_identifier, $identifier, $host, $name, $port, $enabled = false)
-	{
-		$data = array(
-			'host'    => $host,
-			'port'    => $port,
-			'name'    => $name,
-			'enabled' => $enabled
-		);
-		return $this->patch('zones/' . $zone_identifier . '/keyless_certificates/' . $identifier, $data);
-	}
+        return $this->post('zones/'.$zoneIdentifier.'/keyless_certificates', $data);
+    }
 
-	/**
-	 * Delete an SSL certificate (permission needed: #ssl:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 */
-	public function delete($zone_identifier, $identifier)
-	{
-		return $this->delete('zones/' . $zone_identifier . '/keyless_certificates/' . $identifier);
-	}
+    /**
+     * Update SSL configuration (permission needed: #ssl:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     * @param string $host           The keyless SSL hostname
+     * @param string $name           The keyless SSL name
+     * @param int    $port           The keyless SSL port used for CloudFlare <=> client's Keyless SSL server comm
+     * @param bool   $enabled        Whether or not the Keyless SSL is on or off
+     *
+     * @return array|mixed
+     */
+    public function update($zoneIdentifier, $identifier, $host, $name, $port, $enabled = false)
+    {
+        $data = [
+            'host' => $host,
+            'port' => $port,
+            'name' => $name,
+            'enabled' => $enabled,
+        ];
 
+        return $this->patch('zones/'.$zoneIdentifier.'/keyless_certificates/'.$identifier, $data);
+    }
+
+    /**
+     * Delete an SSL certificate (permission needed: #ssl:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     *
+     * @return array|mixed
+     */
+    public function delete($zoneIdentifier, $identifier)
+    {
+        return $this->delete('zones/'.$zoneIdentifier.'/keyless_certificates/'.$identifier);
+    }
 }

--- a/src/Zone/Plan/Plan.php
+++ b/src/Zone/Plan/Plan.php
@@ -1,50 +1,65 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare\Zone;
-use JamesRyanBell\Cloudflare\Api;
+
 use JamesRyanBell\Cloudflare\Zone;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * Zone Plan
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class Plan extends Zone
 {
-	protected $permission_level = array('read' => '#billing:read', 'edit' => '#billing:edit');
+    protected $permissionLevel = [
+        'read' => '#billing:read',
+        'edit' => '#billing:edit',
+    ];
 
-	/**
-	 * Available plans (permission needed: #billing:read)
-	 * List all plans the zone can subscribe to.
-	 * @param string $zone_identifier
-	 */
-	public function available($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/plans');
-	}
+    /**
+     * Available plans (permission needed: #billing:read).
+     *
+     * List all plans the zone can subscribe to.
+     *
+     * @param string $zoneIdentifier
+     *
+     * @return array|mixed
+     */
+    public function available($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/plans');
+    }
 
-	/**
-	 * Available plans (permission needed: #billing:read)
-	 * @param string $zone_identifier
-	 * @param string $identifier      API item identifier tag
-	 */
-	public function details($zone_identifier, $identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/plans/' . $identifier);
-	}
+    /**
+     * Available plans (permission needed: #billing:read).
+     *
+     * @param string $zoneIdentifier
+     * @param string $identifier     API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function details($zoneIdentifier, $identifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/plans/'.$identifier);
+    }
 
-	/**
-	 * Change plan (permission needed: #billing:edit)
-	 * Change the plan level for the zone. This will cancel any previous subscriptions and subscribe the zone to the new plan.
-	 * @param string $zone_identifier
-	 * @param string $identifier      API item identifier tag
-	 */
-	public function change($zone_identifier, $identifier)
-	{
-		return $this->put('zones/' . $zone_identifier . '/plans/' . $identifier . '/subscribe');
-	}
+    /**
+     * Change plan (permission needed: #billing:edit).
+     *
+     * Change the plan level for the zone.
+     * This will cancel any previous subscriptions and subscribe the zone to the new plan.
+     *
+     * @param string $zoneIdentifier
+     * @param string $identifier     API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function change($zoneIdentifier, $identifier)
+    {
+        return $this->put('zones/'.$zoneIdentifier.'/plans/'.$identifier.'/subscribe');
+    }
 }

--- a/src/Zone/Railgun/Railgun.php
+++ b/src/Zone/Railgun/Railgun.php
@@ -1,52 +1,65 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare\Zone;
-use JamesRyanBell\Cloudflare\Api;
+
 use JamesRyanBell\Cloudflare\Zone;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * Railguns for a Zone
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class Railgun extends Zone
 {
-	protected $permission_level = array('read' => '#zone_settings:read', 'edit' => '#zone_settings:edit');
+    protected $permissionLevel = [
+        'read' => '#zone_settings:read',
+        'edit' => '#zone_settings:edit',
+    ];
 
-	/**
-	 * Get available Railguns (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function railguns($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/railguns');
-	}
+    /**
+     * Get available Railguns (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function railguns($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/railguns');
+    }
 
-	/**
-	 * Get Railgun details (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 */
-	public function railgun_details($zone_identifier, $identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/railguns/' . $identifier);
-	}
+    /**
+     * Get Railgun details (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     *
+     * @return array|mixed
+     */
+    public function railgunDetails($zoneIdentifier, $identifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/railguns/'.$identifier);
+    }
 
-	/**
-	 * Connect or disconnect a Railgun (permission needed: #zone_settings:edit)
-	 * @param string $identifier API item identifier tag
-	 * @param bool   $connected  A flag indicating whether the given zone is connected to the Railgun [valid values: (true,false)]
-	 */
-	public function railgun_connected($zone_identifier, $identifier, bool $connected)
-	{
-		$data = array(
-			'connected' => $connected
-		);
-		return $this->get('zones/' . $zone_identifier . '/railguns/' . $identifier, $data);
-	}
+    /**
+     * Connect or disconnect a Railgun (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     * @param bool   $connected      Flag indicating whether the zone is connected to the Railgun
+     *
+     * @return array|mixed
+     */
+    public function railgunConnected($zoneIdentifier, $identifier, bool $connected)
+    {
+        $data = [
+            'connected' => $connected,
+        ];
 
+        return $this->get('zones/'.$zoneIdentifier.'/railguns/'.$identifier, $data);
+    }
 }

--- a/src/Zone/SSL/SSL.php
+++ b/src/Zone/SSL/SSL.php
@@ -1,93 +1,117 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare\Zone;
+
 use JamesRyanBell\Cloudflare\Api;
 use JamesRyanBell\Cloudflare\Zone;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * Custom SSL for a Zone
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class SSL extends Zone
 {
-	protected $permission_level = array('read' => '#ssl:read', 'edit' => '#ssl:edit');
+    protected $permissionLevel = [
+        'read' => '#ssl:read',
+        'edit' => '#ssl:edit',
+    ];
 
-	/**
-	 * List SSL configurations (permission needed: #ssl:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function certificates($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/custom_certificates');
-	}
+    /**
+     * List SSL configurations (permission needed: #ssl:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function certificates($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/custom_certificates');
+    }
 
-	/**
-	 * List SSL configuration details (permission needed: #ssl:read)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 */
-	public function details($zone_identifier, $identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/custom_certificates/' . $identifier);
-	}
+    /**
+     * List SSL configuration details (permission needed: #ssl:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     *
+     * @return array|mixed
+     */
+    public function details($zoneIdentifier, $identifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/custom_certificates/'.$identifier);
+    }
 
-	/**
-	 * Create SSL configuration (permission needed: #ssl:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $certificate     The zone's SSL certificate or certificate and the intermediate(s)
-	 * @param string $private_key     The zone's private key
-	 */
-	public function create($zone_identifier, $certificate, $private_key)
-	{
-		$data = array(
-			'certificate' => $certificate,
-			'private_key' => $private_key
-		);
-		return $this->post('zones/' . $zone_identifier . '/custom_certificates', $data);
-	}
+    /**
+     * Create SSL configuration (permission needed: #ssl:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $certificate    The zone's SSL certificate or certificate and the intermediate(s)
+     * @param string $privateKey     The zone's private key
+     *
+     * @return array|mixed
+     */
+    public function create($zoneIdentifier, $certificate, $privateKey)
+    {
+        $data = [
+            'certificate' => $certificate,
+            'private_key' => $privateKey,
+        ];
 
-	/**
-	 * Update SSL configuration (permission needed: #ssl:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 * @param string $certificate     The zone's SSL certificate or certificate and the intermediate(s)
-	 * @param string $private_key     The zone's private key
-	 */
-	public function update($zone_identifier, $identifier, $certificate, $private_key)
-	{
-		$data = array(
-			'certificate' => $certificate,
-			'private_key' => $private_key
-		);
-		return $this->patch('zones/' . $zone_identifier . '/custom_certificates/' . $identifier, $data);
-	}
+        return $this->post('zones/'.$zoneIdentifier.'/custom_certificates', $data);
+    }
 
-	/**
-	 * Re-prioritize SSL certificates (permission needed: #ssl:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $certificates    Array of ordered certificates
-	 */
-	public function prioritize($zone_identifier, $certificates)
-	{
-		$data = array(
-			'certificates' => $certificates
-		);
-		return $this->patch('zones/' . $zone_identifier . '/custom_certificates/prioritize', $data);
-	}
+    /**
+     * Update SSL configuration (permission needed: #ssl:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     * @param string $certificate    The zone's SSL certificate or certificate and the intermediate(s)
+     * @param string $privateKey     The zone's private key
+     *
+     * @return array|mixed
+     */
+    public function update($zoneIdentifier, $identifier, $certificate, $privateKey)
+    {
+        $data = [
+            'certificate' => $certificate,
+            'private_key' => $privateKey,
+        ];
 
-	/**
-	 * Delete an SSL certificate (permission needed: #ssl:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $identifier
-	 */
-	public function delete($zone_identifier, $identifier)
-	{
-		return $this->delete('zones/' . $zone_identifier . '/custom_certificates/' . $identifier);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/custom_certificates/'.$identifier, $data);
+    }
 
+    /**
+     * Re-prioritize SSL certificates (permission needed: #ssl:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $certificates   Array of ordered certificates
+     *
+     * @return array|mixed
+     */
+    public function prioritize($zoneIdentifier, $certificates)
+    {
+        $data = [
+            'certificates' => $certificates,
+        ];
+
+        return $this->patch('zones/'.$zoneIdentifier.'/custom_certificates/prioritize', $data);
+    }
+
+    /**
+     * Delete an SSL certificate (permission needed: #ssl:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $identifier
+     *
+     * @return array|mixed
+     */
+    public function delete($zoneIdentifier, $identifier)
+    {
+        return $this->delete('zones/'.$zoneIdentifier.'/custom_certificates/'.$identifier);
+    }
 }

--- a/src/Zone/Settings/Settings.php
+++ b/src/Zone/Settings/Settings.php
@@ -1,419 +1,574 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare\Zone;
-use JamesRyanBell\Cloudflare\Api;
+
 use JamesRyanBell\Cloudflare\Zone;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * Zone Settings
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class Settings extends Zone
 {
-	protected $permission_level = array('read' => '#zone_settings:read', 'edit' => '#zone_settings:edit');
+    protected $permissionLevel = [
+        'read' => '#zone_settings:read',
+        'edit' => '#zone_settings:edit',
+    ];
 
-	/**
-	 * Zone settings (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function settings($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings');
-	}
+    /**
+     * Zone settings (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function settings($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings');
+    }
 
-	/**
-	 * Advanced DDOS setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function advanced_ddos($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/advanced_ddos');
-	}
+    /**
+     * Advanced DDOS setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function advancedDdos($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/advanced_ddos');
+    }
 
-	/**
-	 * Get Always Online setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function always_online($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/always_online');
-	}
+    /**
+     * Get Always Online setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function alwaysOnline($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/always_online');
+    }
 
-	/**
-	 * Get Browser Cache TTL setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function browser_cache_ttl($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/browser_cache_ttl');
-	}
+    /**
+     * Get Browser Cache TTL setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function browserCacheTtl($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/browser_cache_ttl');
+    }
 
-	/**
-	 * Get Browser Check setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function browser_check($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/browser_check');
-	}
+    /**
+     * Get Browser Check setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zone_identifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function browserCheck($zone_identifier)
+    {
+        return $this->get('zones/'.$zone_identifier.'/settings/browser_check');
+    }
 
-	/**
-	 * Get Cache Level setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function cache_level($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/cache_level');
-	}
+    /**
+     * Get Cache Level setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function cacheLevel($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/cache_level');
+    }
 
-	/**
-	 * Get Challenge TTL setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function challenge_ttl($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/challenge_ttl');
-	}
+    /**
+     * Get Challenge TTL setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function challengeTtl($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/challenge_ttl');
+    }
 
-	/**
-	 * Get Development Mode setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function development_mode($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/development_mode');
-	}
+    /**
+     * Get Development Mode setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function developmentMode($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/development_mode');
+    }
 
-	/**
-	 * Get Email Obfuscation setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function email_obfuscation($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/email_obfuscation');
-	}
+    /**
+     * Get Email Obfuscation setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function emailObfuscation($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/email_obfuscation');
+    }
 
-	/**
-	 * Get Hotlink Protection setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function hotlink_protection($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/hotlink_protection');
-	}
+    /**
+     * Get Hotlink Protection setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function hotlinkProtection($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/hotlink_protection');
+    }
 
-	/**
-	 * Get IP Geolocation setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function ip_geolocation($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/ip_geolocation');
-	}
+    /**
+     * Get IP Geolocation setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function ipGeolocation($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/ip_geolocation');
+    }
 
-	/**
-	 * Get IP IPv6 setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function ipv6($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/ipv6');
-	}
+    /**
+     * Get IP IPv6 setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function ipv6($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/ipv6');
+    }
 
-	/**
-	 * Get IP Minify setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function minify($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/minify');
-	}
+    /**
+     * Get IP Minify setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function minify($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/minify');
+    }
 
-	/**
-	 * Get Mobile Redirect setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function mobile_redirect($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/mobile_redirect');
-	}
+    /**
+     * Get Mobile Redirect setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function mobileRedirect($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/mobile_redirect');
+    }
 
-	/**
-	 * Get Mirage setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function mirage($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/mirage');
-	}
+    /**
+     * Get Mirage setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function mirage($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/mirage');
+    }
 
-	/**
-	 * Get Polish setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function polish($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/polish');
-	}
+    /**
+     * Get Polish setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function polish($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/polish');
+    }
 
-	/**
-	 * Get Rocket Loader setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function rocket_loader($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/rocket_loader');
-	}
+    /**
+     * Get Rocket Loader setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function rocketLoader($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/rocket_loader');
+    }
 
-	/**
-	 * Get Security Level setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function security_level($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/security_level');
-	}
+    /**
+     * Get Security Level setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function securityLevel($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/security_level');
+    }
 
-	/**
-	 * Get Server Side Exclude setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function server_side_exclude($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/server_side_exclude');
-	}
+    /**
+     * Get Server Side Exclude setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function serverSideExclude($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/server_side_exclude');
+    }
 
-	/**
-	 * Get SSL setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function ssl($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/ssl');
-	}
+    /**
+     * Get SSL setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function ssl($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/ssl');
+    }
 
-	/**
-	 * Get Web Application Firewall (WAF) setting (permission needed: #zone_settings:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function waf($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier . '/settings/waf');
-	}
+    /**
+     * Get Web Application Firewall (WAF) setting (permission needed: #zone_settings:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function waf($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier.'/settings/waf');
+    }
 
-	/**
-	 * Get Web Application Firewall (WAF) setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param array  $items           One or more zone setting objects. Must contain an ID and a value.
-	 */
-	public function edit($zone_identifier, array $data)
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings', $data);
-	}
+    /**
+     * Get Web Application Firewall (WAF) setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param array  $data           $items One or more zone setting objects. Must contain an ID and a value.
+     *
+     * @return array|mixed
+     */
+    public function edit($zoneIdentifier, array $data)
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings', $data);
+    }
 
-	/**
-	 * Change Always Online setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_always_on($zone_identifier, $value = 'on')
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/always_online', $data);
-	}
+    /**
+     * Change Always Online setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeAlwaysOn($zoneIdentifier, $value = 'on')
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change Browser Cache TTL setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param int    $value           Value of the zone setting (default: 14400)
-	 */
-	public function change_browser_cache_ttl($zone_identifier, $value = 14400)
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/browser_cache_ttl', $data);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/always_online', $data);
+    }
 
-	/**
-	 * Change Browser Check setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_browser_check($zone_identifier, $value = 'on')
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/browser_check', $data);
-	}
+    /**
+     * Change Browser Cache TTL setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param int    $value          Value of the zone setting (default: 14400)
+     *
+     * @return array|mixed
+     */
+    public function changeBrowserCacheTtl($zoneIdentifier, $value = 14400)
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change Cache Level setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_cache_level($zone_identifier, $value = 'aggressive')
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/cache_level', $data);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/browser_cache_ttl', $data);
+    }
 
-	/**
-	 * Change Challenge TTL setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param int    $value           Value of the zone setting (default: on)
-	 */
-	public function change_challenge_ttl($zone_identifier, $value = 1800)
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/challenge_ttl', $data);
-	}
+    /**
+     * Change Browser Check setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeBrowserCheck($zoneIdentifier, $value = 'on')
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change Development Mode setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_development_mode($zone_identifier, $value = 'off')
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/development_mode', $data);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/browser_check', $data);
+    }
 
-	/**
-	 * Change Email Obfuscation setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_email_obfuscation($zone_identifier, $value = 'on')
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/email_obfuscation', $data);
-	}
+    /**
+     * Change Cache Level setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeCacheLevel($zoneIdentifier, $value = 'aggressive')
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change Hotlink Protection setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_hotlink_protection($zone_identifier, $value = 'off')
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/hotlink_protection', $data);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/cache_level', $data);
+    }
 
-	/**
-	 * Change IP Geolocation setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_ip_geolocation($zone_identifier, $value = 'on')
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/ip_geolocation', $data);
-	}
+    /**
+     * Change Challenge TTL setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param int    $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeChallengeTtl($zoneIdentifier, $value = 1800)
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change IP Geolocation setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_ipv6($zone_identifier, $value = 'off')
-	{
-		$data = array('value' => $value);
-		return $this->patch('zones/' . $zone_identifier . '/settings/ipv6', $data);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/challenge_ttl', $data);
+    }
 
-	/**
-	 * Change Minify setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting
-	 */
-	public function change_minify($zone_identifier, $data)
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/minify', $data);
-	}
+    /**
+     * Change Development Mode setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeDevelopmentMode($zoneIdentifier, $value = 'off')
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change Mobile Redirect setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_mobile_redirect($zone_identifier, $data)
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/minify', $data);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/development_mode', $data);
+    }
 
-	/**
-	 * Change Mirage setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: off)
-	 */
-	public function change_mirage($zone_identifier, $value = 'off')
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/mirage', $value);
-	}
+    /**
+     * Change Email Obfuscation setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeEmailObfuscation($zoneIdentifier, $value = 'on')
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change Polish setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: off)
-	 */
-	public function change_polish($zone_identifier, $value = 'off')
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/polish', $value);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/email_obfuscation', $data);
+    }
 
-	/**
-	 * Change Rocket Loader setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: off)
-	 */
-	public function change_rocket_loader($zone_identifier, $value = 'off')
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/rocket_loader', $value);
-	}
+    /**
+     * Change Hotlink Protection setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeHotlinkProtection($zoneIdentifier, $value = 'off')
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change Security Level setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: medium)
-	 */
-	public function change_security_level($zone_identifier, $value = 'medium')
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/security_level', $value);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/hotlink_protection', $data);
+    }
 
-	/**
-	 * Change Server Side Exclude setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: on)
-	 */
-	public function change_server_side_exclude($zone_identifier, $value = 'on')
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/server_side_exclude', $value);
-	}
+    /**
+     * Change IP Geolocation setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeIpGeolocation($zoneIdentifier, $value = 'on')
+    {
+        $data = [
+            'value' => $value,
+        ];
 
-	/**
-	 * Change SSL setting (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: off)
-	 */
-	public function change_ssl($zone_identifier, $value = 'off')
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/ssl', $value);
-	}
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/ip_geolocation', $data);
+    }
 
-	/**
-	 * Change Web Application Firewall (WAF) (permission needed: #zone_settings:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 * @param string $value           Value of the zone setting (default: off)
-	 */
-	public function change_waf($zone_identifier, $value = 'off')
-	{
-		return $this->patch('zones/' . $zone_identifier . '/settings/waf', $value);
-	}
+    /**
+     * Change IP Geolocation setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeIpv6($zoneIdentifier, $value = 'off')
+    {
+        $data = [
+            'value' => $value,
+        ];
 
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/ipv6', $data);
+    }
+
+    /**
+     * Change Minify setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting
+     *
+     * @return array|mixed
+     */
+    public function changeMinify($zoneIdentifier, $value)
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/minify', $value);
+    }
+
+    /**
+     * Change Mobile Redirect setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeMobileRedirect($zoneIdentifier, $value = 'on')
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/mobile_redirect', $value);
+    }
+
+    /**
+     * Change Mirage setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: off)
+     *
+     * @return array|mixed
+     */
+    public function changeMirage($zoneIdentifier, $value = 'off')
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/mirage', $value);
+    }
+
+    /**
+     * Change Polish setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: off)
+     *
+     * @return array|mixed
+     */
+    public function changePolish($zoneIdentifier, $value = 'off')
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/polish', $value);
+    }
+
+    /**
+     * Change Rocket Loader setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: off)
+     *
+     * @return array|mixed
+     */
+    public function changeRocketLoader($zoneIdentifier, $value = 'off')
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/rocket_loader', $value);
+    }
+
+    /**
+     * Change Security Level setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: medium)
+     *
+     * @return array|mixed
+     */
+    public function changeSecurityLevel($zoneIdentifier, $value = 'medium')
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/security_level', $value);
+    }
+
+    /**
+     * Change Server Side Exclude setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: on)
+     *
+     * @return array|mixed
+     */
+    public function changeServerSideExclude($zoneIdentifier, $value = 'on')
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/server_side_exclude', $value);
+    }
+
+    /**
+     * Change SSL setting (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: off)
+     *
+     * @return array|mixed
+     */
+    public function changeSsl($zoneIdentifier, $value = 'off')
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/ssl', $value);
+    }
+
+    /**
+     * Change Web Application Firewall (WAF) (permission needed: #zone_settings:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     * @param string $value          Value of the zone setting (default: off)
+     *
+     * @return array|mixed
+     */
+    public function changeWaf($zoneIdentifier, $value = 'off')
+    {
+        return $this->patch('zones/'.$zoneIdentifier.'/settings/waf', $value);
+    }
 }

--- a/src/Zone/Zone.php
+++ b/src/Zone/Zone.php
@@ -1,99 +1,132 @@
 <?php
 
 namespace JamesRyanBell\Cloudflare;
-use JamesRyanBell\Cloudflare\Api;
 
 /**
- * CloudFlare API wrapper
+ * CloudFlare API wrapper.
  *
  * Zone
  * A Zone is a domain name along with its subdomains and other identities
  *
  * @author James Bell <james@james-bell.co.uk>
+ *
  * @version 1
  */
-
 class Zone extends Api
 {
-	protected $permission_level = array('read' => '#zone:read', 'edit' => '#zone:edit');
+    protected $permissionLevel = [
+        'read' => '#zone:read',
+        'edit' => '#zone:edit',
+    ];
 
-	/**
-	 * Create a zone (permission needed: #zone:edit)
-	 * @param string   $domain       The domain name
-	 * @param boolean  $jump_start   Automatically attempt to fetch existing DNS records
-	 * @param null     $organization Organization that this zone will belong to
-	 */
-	public function create($name, $jump_start = true, $organization = null)
-	{
-		$data = array(
-			'name'         => $name,
-			'jump_start'   => $jump_start,
-			'organization' => $organization
-		);
-		return $this->post('zones', $data);
-	}
+    /**
+     * Create a zone (permission needed: #zone:edit).
+     *
+     * @param $name
+     * @param bool $jumpStart    Automatically attempt to fetch existing DNS records
+     * @param null $organization Organization that this zone will belong to
+     *
+     * @return array|mixed
+     *
+     * @internal param string $domain The domain name
+     */
+    public function create($name, $jumpStart = true, $organization = null)
+    {
+        $data = [
+            'name' => $name,
+            'jump_start' => $jumpStart,
+            'organization' => $organization,
+        ];
 
-	/**
-	 * List zones permission needed: #zone:read
-	 * List, search, sort, and filter your zones
-	 * @param string  $name      A domain name
-	 * @param string  $status    Status of the zone (active, pending, initializing, moved, deleted)
-	 * @param integer $page      Page number of paginated results
-	 * @param integer $per_page  Number of zones per page
-	 * @param string  $order     Field to order zones by (name, status, email)
-	 * @param string  $direction Direction to order zones (asc, desc)
-	 * @param string  $match     Whether to match all search requirements or at least one (any) (any, all)
-	 */
-	public function zones($name = '', $status = 'active', $page = 1, $per_page = 20, $order = 'status', $direction = 'desc', $match = 'all')
-	{
-		$data = array(
-			'name'      => $name,
-			'status'    => $status,
-			'page'      => $page,
-			'per_page'  => $per_page,
-			'order'     => $order,
-			'direction' => $direction,
-			'match'     => $match
-		);
-		return $this->get('zones', $data);
-	}
+        return $this->post('zones', $data);
+    }
 
-	/**
-	 * Zone details (permission needed: #zone:read)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function zone($zone_identifier)
-	{
-		return $this->get('zones/' . $zone_identifier);
-	}
+    /**
+     * List zones permission needed: #zone:read.
+     *
+     * List, search, sort, and filter your zones
+     *
+     * @param string $name      A domain name
+     * @param string $status    Status of the zone (active, pending, initializing, moved, deleted)
+     * @param int    $page      Page number of paginated results
+     * @param int    $perPage   Number of zones per page
+     * @param string $order     Field to order zones by (name, status, email)
+     * @param string $direction Direction to order zones (asc, desc)
+     * @param string $match     Whether to match all search requirements or at least one (any) (any, all)
+     *
+     * @return array|mixed
+     */
+    public function zones(
+        $name = '',
+        $status = 'active',
+        $page = 1,
+        $perPage = 20,
+        $order = 'status',
+        $direction = 'desc',
+        $match = 'all'
+    ) {
+        $data = [
+            'name' => $name,
+            'status' => $status,
+            'page' => $page,
+            'per_page' => $perPage,
+            'order' => $order,
+            'direction' => $direction,
+            'match' => $match,
+        ];
 
-	/**
-	 * Pause all CloudFlare features (permission needed: #zone:edit)
-	 * This will pause all features and settings for the zone. DNS will still resolve
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function pause($zone_identifier)
-	{
-		return $this->put('zones/' . $zone_identifier . '/pause');
-	}
+        return $this->get('zones', $data);
+    }
 
-	/**
-	 * Re-enable all CloudFlare features (permission needed: #zone:edit)
-	 * This will restore all features and settings for the zone
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function unpause($zone_identifier)
-	{
-		return $this->put('zones/' . $zone_identifier . '/unpause');
-	}
+    /**
+     * Zone details (permission needed: #zone:read).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function zone($zoneIdentifier)
+    {
+        return $this->get('zones/'.$zoneIdentifier);
+    }
 
-	/**
-	 * Delete a zone (permission needed: #zone:edit)
-	 * @param string $zone_identifier API item identifier tag
-	 */
-	public function delete_zone($zone_identifier)
-	{
-		return $this->delete('zones/' . $zone_identifier);
-	}
+    /**
+     * Pause all CloudFlare features (permission needed: #zone:edit).
+     *
+     * This will pause all features and settings for the zone. DNS will still resolve
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function pause($zoneIdentifier)
+    {
+        return $this->put('zones/'.$zoneIdentifier.'/pause');
+    }
 
+    /**
+     * Re-enable all CloudFlare features (permission needed: #zone:edit).
+     *
+     * This will restore all features and settings for the zone
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function unpause($zoneIdentifier)
+    {
+        return $this->put('zones/'.$zoneIdentifier.'/unpause');
+    }
+
+    /**
+     * Delete a zone (permission needed: #zone:edit).
+     *
+     * @param string $zoneIdentifier API item identifier tag
+     *
+     * @return array|mixed
+     */
+    public function deleteZone($zoneIdentifier)
+    {
+        return $this->delete('zones/'.$zoneIdentifier);
+    }
 }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1,102 +1,108 @@
 <?php
 
-use JamesRyanBell\Cloudflare;
+namespace JamesRyanBell\CloudflareTests;
+
 use JamesRyanBell\Cloudflare\Api as Api;
 
-class ApiTest extends PHPUnit_Framework_TestCase {
+class ApiTest extends \PHPUnit_Framework_TestCase
+{
+    public function testApiClassFound()
+    {
+        $api = new Api();
+        $this->assertTrue((bool) $api);
+    }
 
-	public function testApiClassFound()
-	{
-		$api = new Api;
-		$this->assertTrue((bool)$api);
-	}
+    public function testApiInitialised()
+    {
+        $api = new Api('email@example.com', 'Auth Key');
+        $this->assertEquals('email@example.com', $api->email);
+        $this->assertEquals('Auth Key', $api->authKey);
+    }
 
-	public function testApiInitialised()
-	{
-		$api = new Api('email@example.com', 'Auth Key');
-		$this->assertEquals('email@example.com', $api->email);
-		$this->assertEquals('Auth Key', $api->auth_key);
-	}
+    public function testApiInitialisedFromPreviousObject()
+    {
+        $client = new Api('email@example.com', 'Auth Key');
+        $api = new Api($client);
+        $this->assertEquals('email@example.com', $api->email);
+        $this->assertEquals('Auth Key', $api->authKey);
+    }
 
-	public function testApiInitialisedFromPreviousObject()
-	{
-		$client = new Api('email@example.com', 'Auth Key');
-		$api = new Api($client);
-		$this->assertEquals('email@example.com', $api->email);
-		$this->assertEquals('Auth Key', $api->auth_key);
-	}
+    public function testSetAuthKey()
+    {
+        $api = new Api();
+        $api->setAuthKey('Auth Key');
+        $this->assertEquals('Auth Key', $api->authKey);
+    }
 
-	public function testSetAuthKey()
-	{
-		$api = new Api;
-		$api->setAuthKey('Auth Key');
-		$this->assertEquals('Auth Key', $api->auth_key);
-	}
+    public function testSetEmail()
+    {
+        $api = new Api();
+        $api->setEmail('email@example.com');
+        $this->assertEquals('email@example.com', $api->email);
+    }
 
-	public function testSetEmail()
-	{
-		$api = new Api;
-		$api->setEmail('email@example.com');
-		$this->assertEquals('email@example.com', $api->email);
-	}
+    public function testSetCurlOption()
+    {
+        $api = new Api();
+        $api->setCurlOption(CURLOPT_TIMEOUT, 5);
+        $this->assertEquals(5, $api->curlOptions[CURLOPT_TIMEOUT]);
+    }
 
-	public function testSetCurlOption()
-	{
-		$api = new Api;
-		$api->setCurlOption(CURLOPT_TIMEOUT, 5);
-		$this->assertEquals(5, $api->curl_options[CURLOPT_TIMEOUT]);
-	}
+    public function testHttpNoCredentials()
+    {
+        $http = new Api();
+        try {
+            $http->get('test');
+            $this->fail('Expected exception not thrown');
+        } catch (\Exception $e) {
+            $this->assertEquals('Authentication information must be provided', $e->getMessage());
+        }
+    }
 
-	public function testHttpNoCredentials()
-	{
-		$http = new Api();
-		try {
-			$http->get('test');
-			$this->fail("Expected exception not thrown");
-		} catch(Exception $e) {
-			$this->assertEquals("Authentication information must be provided", $e->getMessage());
-		}
-	}
+    public function testHttpGetMethodSet()
+    {
+        $api = new Api('email@example.com', 'Auth Key');
+        $result = $api->get('test');
+        $this->assertEquals('get', $result['method']);
+    }
 
-	public function testHttpGetMethodSet() {
-		$api = new Api('email@example.com', 'Auth Key');
-		$result = $api->get('test');
-		$this->assertEquals("get", $result['method']);
-	}
+    public function testHttpPostMethodSet()
+    {
+        $api = new Api('email@example.com', 'Auth Key');
+        $result = $api->post('test');
+        $this->assertEquals('post', $result['method']);
+    }
 
-	public function testHttpPostMethodSet() {
-		$api = new Api('email@example.com', 'Auth Key');
-		$result = $api->post('test');
-		$this->assertEquals("post", $result['method']);
-	}
+    public function testHttpPutMethodSet()
+    {
+        $api = new Api('email@example.com', 'Auth Key');
+        $result = $api->put('test');
+        $this->assertEquals('put', $result['method']);
+    }
 
-	public function testHttpPutMethodSet() {
-		$api = new Api('email@example.com', 'Auth Key');
-		$result = $api->put('test');
-		$this->assertEquals("put", $result['method']);
-	}
+    public function testHttpPatchMethodSet()
+    {
+        $api = new Api('email@example.com', 'Auth Key');
+        $result = $api->patch('test');
+        $this->assertEquals('patch', $result['method']);
+    }
 
-	public function testHttpPatchMethodSet() {
-		$api = new Api('email@example.com', 'Auth Key');
-		$result = $api->patch('test');
-		$this->assertEquals("patch", $result['method']);
-	}
+    public function testHttpDeleteMethodSet()
+    {
+        $api = new Api('email@example.com', 'Auth Key');
+        $result = $api->delete('test');
+        $this->assertEquals('delete', $result['method']);
+    }
 
-	public function testHttpDeleteMethodSet() {
-		$api = new Api('email@example.com', 'Auth Key');
-		$result = $api->delete('test');
-		$this->assertEquals("delete", $result['method']);
-	}
+    public function testHttpRequest()
+    {
+        $reflectionClass = new \ReflectionClass('\\JamesryanBell\Cloudflare\\Api');
+        $method = $reflectionClass->getMethod('request');
+        $method->setAccessible(true);
 
-	public function testHttpRequest() {
-		$reflectionClass = new ReflectionClass('\\JamesryanBell\Cloudflare\\Api');
-		$method = $reflectionClass->getMethod('request');
-		$method->setAccessible(true);
+        $api = new Api('email@example.com', 'Auth Key');
+        $result = $method->invoke($api, 'test');
 
-		$api = new Api('email@example.com', 'Auth Key');
-		$result = $method->invoke($api, 'test');
-
-		$this->assertEquals('get', $result['method']);
-	}
-
+        $this->assertEquals('get', $result['method']);
+    }
 }


### PR DESCRIPTION
This PR is only about code style and introducing compliance to PSR-2 standards, which is the *de facto* standard for libraries.

*When reading the PR files, please consider using `SourceTree` or any software that allows you to `Ignore whitespace`, because the indentation moved from tab to spaces and you wouldn't be able to check the real changes easily.*

It has been tested with both [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) and [php-cs-fixer](http://cs.sensiolabs.org/).

**Major BC problem:**

Unfortunately, due to the renaming of the methods from snake case to camel case, all the user calls would be broken.

I can see 2 solutions to this problem:

1. **Proper solution**: Tag the latest commit **before merging** this PR, with a non-stable version number such as v0.0.1, then merge the PR and edit `readme.md` to add a warning and tell people to change their composer.json file requirements to v0.0.1if they do not want to change their calls yet. Maybe even add a post update / post install script that echoes something into the terminal during operations.

2. **Dirty solution**: use the magic method `__call` in every files to map from snake to camel case. We can use `Zend\Filter\Word\UnderscoreToCamelCase` ([doc](http://framework.zend.com/manual/current/en/modules/zend.filter.word.html#underscoretocamelcase)) and `method-exists($this, $filter->filter($methodCalled));` ([doc](http://php.net/manual/en/function.method-exists.php)).