### PR TITLE
Resolve problem with scalar type hints

### DIFF
--- a/src/CloudFlare/Organizations/Firewall/AccessRules/Rules.php
+++ b/src/CloudFlare/Organizations/Firewall/AccessRules/Rules.php
@@ -51,7 +51,7 @@ class Rules extends Api
      * @param object      $configuration   Rule configuration
      * @param string|null $notes           A personal note about the rule. Typically used as a reminder or explanation for the rule.
      */
-    public function create($organization_id, $mode, object $configuration, $notes = null)
+    public function create($organization_id, $mode, $configuration, $notes = null)
     {
         $data = array(
             'mode'          => $mode,
@@ -70,7 +70,7 @@ class Rules extends Api
      * @param object|null $configuration   Rule configuration
      * @param string|null $notes           A personal note about the rule. Typically used as a reminder or explanation for the rule.
      */
-    public function update($organization_id, $identifier, $mode = null, object $configuration = null, $notes = null)
+    public function update($organization_id, $identifier, $mode = null, $configuration = null, $notes = null)
     {
         $data = array(
             'mode'          => $mode,

--- a/src/CloudFlare/Railguns.php
+++ b/src/CloudFlare/Railguns.php
@@ -74,7 +74,7 @@ class Railguns extends Api
      * @param string    $zone_identifier API item identifier tag
      * @param bool|null $enabled         Flag to determine if the Railgun is accepting connections
      */
-    public function enabled($zone_identifier, bool $enabled = null)
+    public function enabled($zone_identifier, $enabled = null)
     {
         $data = array(
             'enabled' => $enabled

--- a/src/CloudFlare/User/Firewall/AccessRules.php
+++ b/src/CloudFlare/User/Firewall/AccessRules.php
@@ -76,7 +76,7 @@ class AccessRules extends Api
      * @param object|null $configuration Rule configuration
      * @param string|null $notes         A personal note about the rule. Typically used as a reminder or explanation for the rule.
      */
-    public function update($identifier, $mode = null, object $configuration = null, $notes = null)
+    public function update($identifier, $mode = null, $configuration = null, $notes = null)
     {
         $data = array(
             'mode'          => $mode,

--- a/src/CloudFlare/Zone.php
+++ b/src/CloudFlare/Zone.php
@@ -26,7 +26,7 @@ class Zone extends Api
      * @param boolean|null $jump_start   Automatically attempt to fetch existing DNS records
      * @param int|null     $organization To create a zone owned by an organization, specify the organization parameter. Organization objects can be found in the User or User's Organizations endpoints. You must pass at least the ID of the organization.
      */
-    public function create($name, bool $jump_start = null, int $organization = null)
+    public function create($name, $jump_start = null, $organization = null)
     {
         $data = array(
             'name'         => $name,

--- a/src/CloudFlare/Zone/Analytics.php
+++ b/src/CloudFlare/Zone/Analytics.php
@@ -35,7 +35,7 @@ class Analytics extends Api
      *                                          Analytics data is processed and aggregated asynchronously and can sometimes lead to recent data points being incomplete if this value is set to false.
      *                                          If a start date provided is earlier than a date for which data is available, the API will return 0's for those dates until the first available date with data
      */
-    public function dashboard($zone_identifier, $since = null, $until = null, bool $continuous = null)
+    public function dashboard($zone_identifier, $since = null, $until = null, $continuous = null)
     {
         $data = array(
             'since'      => $since,
@@ -57,7 +57,7 @@ class Analytics extends Api
      *                                          Analytics data is processed and aggregated asynchronously and can sometimes lead to recent data points being incomplete if this value is set to false.
      *                                          If a start date provided is earlier than a date for which data is available, the API will return 0's for those dates until the first available date with data
      */
-    public function colos($zone_identifier, $since = null, $until = null, bool $continuous = null)
+    public function colos($zone_identifier, $since = null, $until = null, $continuous = null)
     {
         $data = array(
             'since'      => $since,

--- a/src/CloudFlare/Zone/Cache.php
+++ b/src/CloudFlare/Zone/Cache.php
@@ -29,7 +29,7 @@ class Cache extends Api
      * @param boolean|null  $purge_everything  A flag that indicates all resources in CloudFlare's cache should be removed.
      *                                         Note: This may have dramatic affects on your origin server load after performing this action. (true)
      */
-    public function purge($identifier, bool $purge_everything = null)
+    public function purge($identifier, $purge_everything = null)
     {
         $data = array(
             'purge_everything' => $purge_everything

--- a/src/CloudFlare/Zone/Firewall/AccessRules.php
+++ b/src/CloudFlare/Zone/Firewall/AccessRules.php
@@ -62,7 +62,7 @@ class AccessRules extends Api
      * @param object      $configuration Rule configuration
      * @param string|null $notes         A personal note about the rule. Typically used as a reminder or explanation for the rule.
      */
-    public function create($zone_id, $mode, $configuration, string $notes = null)
+    public function create($zone_id, $mode, $configuration, $notes = null)
     {
         $data = array(
             'mode'          => $mode,

--- a/src/CloudFlare/Zone/Railgun.php
+++ b/src/CloudFlare/Zone/Railgun.php
@@ -61,7 +61,7 @@ class Railgun extends Api
      * @param string $identifier      API item identifier tag
      * @param bool   $connected       A flag indicating whether the given zone is connected to the Railgun [valid values: (true,false)]
      */
-    public function connected($zone_identifier, $identifier, bool $connected)
+    public function connected($zone_identifier, $identifier, $connected)
     {
         $data = array(
             'connected' => $connected

--- a/src/CloudFlare/Zone/WAF/Packages.php
+++ b/src/CloudFlare/Zone/WAF/Packages.php
@@ -66,7 +66,7 @@ class Packages extends Api
      * @param string|null $sensitivity     The sensitivity of the firewall package.
      * @param string|null $action_mode     The default action that will be taken for rules under the firewall package.
      */
-    public function update(string $zone_identifier, string $identifier, string $sensitivity = null, string $action_mode = null)
+    public function update(string $zone_identifier, $identifier, $sensitivity = null, $action_mode = null)
     {
         $data = array(
             'sensitivity' => $sensitivity,

--- a/src/CloudFlare/Zone/WAF/Packages/Rules.php
+++ b/src/CloudFlare/Zone/WAF/Packages/Rules.php
@@ -39,7 +39,7 @@ class Rules extends Api
      * @param string|null $direction   Direction to order rules
      * @param string|null $match       Whether to match all search requirements or at least one (any)
      */
-    public function rules($zone_id, $package_id, $description = null, object $mode = null, $priority = null, $group_id = null, $page = null, $per_page = null, $order = null, $direction = null, $match = null)
+    public function rules($zone_id, $package_id, $description = null, $mode = null, $priority = null, $group_id = null, $page = null, $per_page = null, $order = null, $direction = null, $match = null)
     {
         $data = array(
             'description' => $description,


### PR DESCRIPTION
Remove scalar type hints as they available in PHP 7 only. Related to #9.