### PR TITLE
Removed premature permission check to reduce API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 /.idea
 /.ds_store
 
-/composer.lock
-
 /vendor
 /output
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea
-/vendor
 .ds_store
+
+composer.lock
+
+/vendor
 /output
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /vendor
 .ds_store
 /output

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-.idea
-.ds_store
+/.idea
+/.ds_store
 
-composer.lock
+/composer.lock
 
 /vendor
 /output

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "21d9def09331d783e81b6c4230259e7e",
-    "content-hash": "16703b45f416edbe33cd78c9b69287a4",
+    "hash": "aef90cb93243e1d1a108d00087cc7b99",
+    "content-hash": "dadac74806b62c625879e32524e69f16",
     "packages": [],
     "packages-dev": [
         {
@@ -234,48 +234,6 @@
             "time": "2016-06-24 23:00:38"
         },
         {
-            "name": "myclabs/deep-copy",
-            "version": "1.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "a8773992b362b58498eed24bf85005f363c34771"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/a8773992b362b58498eed24bf85005f363c34771",
-                "reference": "a8773992b362b58498eed24bf85005f363c34771",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "time": "2015-11-20 12:04:31"
-        },
-        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0",
             "source": {
@@ -485,40 +443,39 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.0",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9"
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/900370c81280cc0d942ffbc5912d80464eaee7e9",
-                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": ">=5.3.3",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "^1.4.2",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "phpunit/php-token-stream": "~1.3",
                 "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0|~2.0"
+                "sebastian/version": "~1.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "~4"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.4.0",
+                "ext-xdebug": ">=2.2.1",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -544,7 +501,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-06-03 05:03:56"
+            "time": "2015-10-06 15:47:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -729,16 +686,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.4.7",
+            "version": "4.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6c8a756c17a1a92a066c99860eb57922e8b723da"
+                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6c8a756c17a1a92a066c99860eb57922e8b723da",
-                "reference": "6c8a756c17a1a92a066c99860eb57922e8b723da",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
                 "shasum": ""
             },
             "require": {
@@ -747,26 +704,20 @@
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
+                "php": ">=5.3.3",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0",
+                "phpunit/php-code-coverage": "~2.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
+                "phpunit/phpunit-mock-objects": "~2.3",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "^1.3 || ^2.0",
+                "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0|~2.0",
+                "sebastian/version": "~1.0",
                 "symfony/yaml": "~2.1|~3.0"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
             },
             "suggest": {
                 "phpunit/php-invoker": "~1.1"
@@ -777,7 +728,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4.x-dev"
+                    "dev-master": "4.8.x-dev"
                 }
             },
             "autoload": {
@@ -803,33 +754,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:55:27"
+            "time": "2016-07-21 06:48:14"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.2.3",
+            "version": "2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "b13d0d9426ced06958bd32104653526a6c998a52"
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b13d0d9426ced06958bd32104653526a6c998a52",
-                "reference": "b13d0d9426ced06958bd32104653526a6c998a52",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "~4.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -837,7 +785,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -862,7 +810,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-06-12 07:37:26"
+            "time": "2015-10-02 06:51:40"
         },
         {
             "name": "psr/http-message",
@@ -1013,51 +961,6 @@
                 "test"
             ],
             "time": "2016-01-20 17:44:41"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
         },
         {
             "name": "sebastian/comparator",
@@ -1344,52 +1247,6 @@
             "time": "2015-10-12 03:26:01"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
-        },
-        {
             "name": "sebastian/recursion-context",
             "version": "1.0.2",
             "source": {
@@ -1443,70 +1300,20 @@
             "time": "2015-11-11 19:50:13"
         },
         {
-            "name": "sebastian/resource-operations",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
-        },
-        {
             "name": "sebastian/version",
-            "version": "2.0.0",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
                 "shasum": ""
             },
-            "require": {
-                "php": ">=5.6"
-            },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1525,7 +1332,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2015-06-21 13:59:46"
         },
         {
             "name": "symfony/config",
@@ -1904,5 +1711,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": {
+        "php": ">=5.4.0"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "aef90cb93243e1d1a108d00087cc7b99",
-    "content-hash": "dadac74806b62c625879e32524e69f16",
+    "hash": "21d9def09331d783e81b6c4230259e7e",
+    "content-hash": "16703b45f416edbe33cd78c9b69287a4",
     "packages": [],
     "packages-dev": [
         {
@@ -1711,7 +1711,5 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": {
-        "php": ">=5.4.0"
-    }
+    "platform-dev": []
 }

--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -2,7 +2,7 @@
 
 namespace Cloudflare;
 
-use CloudFlare\Exception\AuthenticationException;
+use Cloudflare\Exception\AuthenticationException;
 use Exception;
 
 /**
@@ -191,7 +191,7 @@ class Api
      */
     protected function request($path, array $data = null, $method = null, $permission_level = null)
     {
-        if (!isset($this->email, $this->auth_key)) {
+        if (!isset($this->email, $this->auth_key) || false === filter_var($this->email, FILTER_VALIDATE_EMAIL)) {
             throw new AuthenticationException('Authentication information must be provided');
         }
 

--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -81,7 +81,7 @@ class Api
     /**
      * Setter to allow the adding / changing of the Curl options that will be used within the HTTP requests
      *
-     * @param long  $key   The CURLOPT_XXX option to set e.g. CURLOPT_TIMEOUT
+     * @param int   $key   The CURLOPT_XXX option to set e.g. CURLOPT_TIMEOUT
      * @param mixed $value The value to be set on option e.g. 10
      */
     public function setCurlOption($key, $value)

--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -2,6 +2,7 @@
 
 namespace Cloudflare;
 
+use CloudFlare\Exception\AuthenticationException;
 use Exception;
 
 /**
@@ -190,9 +191,10 @@ class Api
      */
     protected function request($path, array $data = null, $method = null, $permission_level = null)
     {
-        if (!isset($this->email) || !isset($this->auth_key)) {
-            throw new Exception('Authentication information must be provided');
+        if (!isset($this->email, $this->auth_key)) {
+            throw new AuthenticationException('Authentication information must be provided');
         }
+
         $data = (is_null($data) ? [] : $data);
         $method = (is_null($method) ? 'get' : $method);
         $permission_level = (is_null($permission_level) ? 'read' : $permission_level);

--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -94,6 +94,8 @@ class Api
      *
      * @param string     $path Path of the endpoint
      * @param array|null $data Data to be sent along with the request
+     *
+     * @return mixed
      */
     public function get($path, array $data = null)
     {
@@ -105,6 +107,8 @@ class Api
      *
      * @param string     $path Path of the endpoint
      * @param array|null $data Data to be sent along with the request
+     *
+     * @return mixed
      */
     public function post($path, array $data = null)
     {
@@ -116,6 +120,8 @@ class Api
      *
      * @param string     $path Path of the endpoint
      * @param array|null $data Data to be sent along with the request
+     *
+     * @return mixed
      */
     public function put($path, array $data = null)
     {
@@ -127,6 +133,8 @@ class Api
      *
      * @param string     $path Path of the endpoint
      * @param array|null $data Data to be sent along with the request
+     *
+     * @return mixed
      */
     public function delete($path, array $data = null)
     {
@@ -138,6 +146,8 @@ class Api
      *
      * @param string     $path Path of the endpoint
      * @param array|null $data Data to be sent along with the request
+     *
+     * @return mixed
      */
     public function patch($path, array $data = null)
     {
@@ -149,9 +159,11 @@ class Api
      *
      * API call method for sending requests using GET, POST, PUT, DELETE OR PATCH
      *
-     * @param string      $path             Path of the endpoint
-     * @param array|null  $data             Data to be sent along with the request
-     * @param string|null $method           Type of method that should be used ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')
+     * @param string      $path   Path of the endpoint
+     * @param array|null  $data   Data to be sent along with the request
+     * @param string|null $method Type of method that should be used ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')
+     *
+     * @return mixed
      */
     protected function request($path, array $data = null, $method = null)
     {

--- a/src/CloudFlare/Certificates.php
+++ b/src/CloudFlare/Certificates.php
@@ -17,13 +17,6 @@ namespace Cloudflare;
 class Certificates extends Api
 {
     /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => null, 'edit' => null];
-
-    /**
      * List Certificates
      * List all existing CloudFlare-issued Certificates for a given zone. Use your Certificates API Key as your
      * User Service Key when calling this endpoint

--- a/src/CloudFlare/Exception/AuthenticationException.php
+++ b/src/CloudFlare/Exception/AuthenticationException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CloudFlare\Exception;
+
+class AuthenticationException extends \RuntimeException
+{
+
+}

--- a/src/CloudFlare/Exception/AuthenticationException.php
+++ b/src/CloudFlare/Exception/AuthenticationException.php
@@ -4,5 +4,4 @@ namespace Cloudflare\Exception;
 
 class AuthenticationException extends \RuntimeException
 {
-
 }

--- a/src/CloudFlare/Exception/AuthenticationException.php
+++ b/src/CloudFlare/Exception/AuthenticationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CloudFlare\Exception;
+namespace Cloudflare\Exception;
 
 class AuthenticationException extends \RuntimeException
 {

--- a/src/CloudFlare/Exception/UnauthorizedException.php
+++ b/src/CloudFlare/Exception/UnauthorizedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Cloudflare\Exception;
+
+class UnauthorizedException extends \RuntimeException
+{
+
+}

--- a/src/CloudFlare/Exception/UnauthorizedException.php
+++ b/src/CloudFlare/Exception/UnauthorizedException.php
@@ -4,5 +4,4 @@ namespace Cloudflare\Exception;
 
 class UnauthorizedException extends \RuntimeException
 {
-
 }

--- a/src/CloudFlare/IPs.php
+++ b/src/CloudFlare/IPs.php
@@ -15,13 +15,6 @@ namespace Cloudflare;
 class IPs extends Api
 {
     /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => null, 'edit' => null];
-
-    /**
      * CloudFlare IPs
      * Get CloudFlare IPs
      */

--- a/src/CloudFlare/Organizations.php
+++ b/src/CloudFlare/Organizations.php
@@ -14,13 +14,6 @@ namespace Cloudflare;
 class Organizations extends Api
 {
     /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#organization:read', 'edit' => '#organization:edit'];
-
-    /**
      * Organization details (permission needed: #organization:read)
      * Get information about a specific organization that you are a member of
      *

--- a/src/CloudFlare/Organizations/Firewall/AccessRules/Rules.php
+++ b/src/CloudFlare/Organizations/Firewall/AccessRules/Rules.php
@@ -18,13 +18,6 @@ use Cloudflare\Organizations\Firewall;
 class Rules extends Api
 {
     /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#organization:read', 'edit' => '#organization:edit'];
-
-    /**
      * List access rules (permission needed: #organization:read)
      * Search, sort, and filter IP/country access rules
      *

--- a/src/CloudFlare/Organizations/Invites.php
+++ b/src/CloudFlare/Organizations/Invites.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Organizations;
 
 use Cloudflare\Api;
-use Cloudflare\Organizations;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Organizations;
  */
 class Invites extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#organization:read', 'edit' => '#organization:edit'];
-
     /**
      * Create invitation (permission needed: #organization:read)
      * Invite a User to become a Member of an Organization

--- a/src/CloudFlare/Organizations/Members.php
+++ b/src/CloudFlare/Organizations/Members.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Organizations;
 
 use Cloudflare\Api;
-use Cloudflare\Organizations;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Organizations;
  */
 class Members extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#organization:read', 'edit' => '#organization:edit'];
-
     /**
      * List members (permission needed: #organization:read)
      * List all members of a organization

--- a/src/CloudFlare/Organizations/Railguns.php
+++ b/src/CloudFlare/Organizations/Railguns.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Organizations;
 
 use Cloudflare\Api;
-use Cloudflare\Organizations;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Organizations;
  */
 class Railguns extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#organization:read', 'edit' => '#organization:edit'];
-
     /**
      * Create Railgun (permission needed: #organization:edit)
      *

--- a/src/CloudFlare/Organizations/Roles.php
+++ b/src/CloudFlare/Organizations/Roles.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Organizations;
 
 use Cloudflare\Api;
-use Cloudflare\Organizations;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Organizations;
  */
 class Roles extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#organization:read', 'edit' => '#organization:edit'];
-
     /**
      * List roles (permission needed: #organization:read)
      * Get all available roles for an organization

--- a/src/CloudFlare/Organizations/VirtualDns.php
+++ b/src/CloudFlare/Organizations/VirtualDns.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Organizations;
 
 use Cloudflare\Api;
-use Cloudflare\Organizations;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Organizations;
  */
 class Virtual_Dns extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#dns_records:read', 'edit' => '#dns_records:edit'];
-
     /**
      * Get Virtual DNS Clusters (permission needed: #dns_records:read)
      * List configured Virtual DNS clusters for an organization

--- a/src/CloudFlare/Railguns.php
+++ b/src/CloudFlare/Railguns.php
@@ -15,13 +15,6 @@ namespace Cloudflare;
 class Railguns extends Api
 {
     /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#railgun:read', 'edit' => '#railgun:edit'];
-
-    /**
      * Create Railgun (permission needed: #railgun:edit)
      *
      * @param string $name Readable identifier of the railgun

--- a/src/CloudFlare/User.php
+++ b/src/CloudFlare/User.php
@@ -15,13 +15,6 @@ namespace Cloudflare;
 class User extends Api
 {
     /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => null, 'edit' => null];
-
-    /**
      * User details
      */
     public function user()

--- a/src/CloudFlare/User/Billing.php
+++ b/src/CloudFlare/User/Billing.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\User;
 
 use Cloudflare\Api;
-use Cloudflare\User;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\User;
  */
 class Billing extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#billing:read', 'edit' => '#billing:edit'];
-
     /**
      * Billing Profile (permission needed: #billing:read)
      * Access your billing profile object

--- a/src/CloudFlare/User/Billing/Subscriptions/Apps.php
+++ b/src/CloudFlare/User/Billing/Subscriptions/Apps.php
@@ -69,7 +69,7 @@ class Apps extends Api
      *
      * @param string $identifier
      */
-    public function info(string $identifier)
+    public function info($identifier)
     {
         return $this->get('/user/billing/subscriptions/apps/'.$identifier);
     }

--- a/src/CloudFlare/User/Billing/Subscriptions/Apps.php
+++ b/src/CloudFlare/User/Billing/Subscriptions/Apps.php
@@ -4,7 +4,6 @@ namespace Cloudflare\User\Billing\Subscriptions;
 
 use Cloudflare\Api;
 use Cloudflare\User;
-use Cloudflare\User\Billing;
 
 /**
  * CloudFlare API wrapper
@@ -18,13 +17,6 @@ use Cloudflare\User\Billing;
  */
 class Apps extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#billing:read', 'edit' => '#billing:edit'];
-
     /**
      * List (permission needed: #billing:read)
      * List all of your app subscriptions

--- a/src/CloudFlare/User/Billing/Subscriptions/Zones.php
+++ b/src/CloudFlare/User/Billing/Subscriptions/Zones.php
@@ -4,7 +4,6 @@ namespace Cloudflare\User\Billing\Subscriptions;
 
 use Cloudflare\Api;
 use Cloudflare\User;
-use Cloudflare\User\Billing;
 
 /**
  * CloudFlare API wrapper
@@ -18,13 +17,6 @@ use Cloudflare\User\Billing;
  */
 class Zones extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#billing:read', 'edit' => '#billing:edit'];
-
     /**
      * List (permission needed: #billing:read)
      * List all of your zone plan subscriptions

--- a/src/CloudFlare/User/Firewall/AccessRules.php
+++ b/src/CloudFlare/User/Firewall/AccessRules.php
@@ -4,7 +4,6 @@ namespace Cloudflare\User\Firewall;
 
 use Cloudflare\Api;
 use Cloudflare\User;
-use Cloudflare\User\Firewall;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\User\Firewall;
  */
 class AccessRules extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#billing:read', 'edit' => '#billing:edit'];
-
     /**
      * List access rules (permission needed: #billing:read)
      * Search, sort, and filter IP/country access rules

--- a/src/CloudFlare/User/Invites.php
+++ b/src/CloudFlare/User/Invites.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\User;
 
 use Cloudflare\Api;
-use Cloudflare\User;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\User;
  */
 class Invites extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#invites:read', 'edit' => '#invites:edit'];
-
     /**
      * List invitations (permission needed: #invites:read)
      * List all invitations associated with my user

--- a/src/CloudFlare/User/Organizations.php
+++ b/src/CloudFlare/User/Organizations.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\User;
 
 use Cloudflare\Api;
-use Cloudflare\User;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\User;
  */
 class Organizations extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#organizations:read', 'edit' => '#organizations:edit'];
-
     /**
      * List organizations (permission needed: #organizations:read)
      * List organizations the user is associated with

--- a/src/CloudFlare/User/VirtualDns.php
+++ b/src/CloudFlare/User/VirtualDns.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\User;
 
 use Cloudflare\Api;
-use Cloudflare\User;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\User;
  */
 class Virtual_Dns extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#dns_records:read', 'edit' => '#dns_records:edit'];
-
     /**
      * Get Virtual DNS Clusters (permission needed: #dns_records:read)
      * List configured Virtual DNS clusters for a user

--- a/src/CloudFlare/Zone.php
+++ b/src/CloudFlare/Zone.php
@@ -15,13 +15,6 @@ namespace Cloudflare;
 class Zone extends Api
 {
     /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone:read', 'edit' => '#zone:edit'];
-
-    /**
      * Create a zone (permission needed: #zone:edit)
      *
      * @param string    $name         The domain name

--- a/src/CloudFlare/Zone/Analytics.php
+++ b/src/CloudFlare/Zone/Analytics.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Zone;
  */
 class Analytics extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#analytics:read', 'edit' => '#analytics:edit'];
-
     /**
      * Dashboard (permission needed: #analytics:read)
      * The dashboard view provides both totals and timeseries data for the given zone and time period across the entire CloudFlare network.

--- a/src/CloudFlare/Zone/Cache.php
+++ b/src/CloudFlare/Zone/Cache.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Zone;
  */
 class Cache extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone:read', 'edit' => '#zone:edit'];
-
     /**
      * Purge all files (permission needed: #zone:edit)
      * Remove ALL files from CloudFlare's cache

--- a/src/CloudFlare/Zone/CustomPages.php
+++ b/src/CloudFlare/Zone/CustomPages.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Zone;
  */
 class CustomPages extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone_settings:read', 'edit' => '#zone_settings:edit'];
-
     /**
      * Available Custom Pages (permission needed: #zone_settings:read)
      *

--- a/src/CloudFlare/Zone/CustomSSL.php
+++ b/src/CloudFlare/Zone/CustomSSL.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Zone;
  */
 class CustomSSL extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#ssl:read', 'edit' => '#ssl:edit'];
-
     /**
      * List SSL configurations (permission needed: #ssl:edit)
      * List, search, sort, and filter all of your custom SSL certificates

--- a/src/CloudFlare/Zone/Dns.php
+++ b/src/CloudFlare/Zone/Dns.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Zone;
  */
 class Dns extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#dns_records:read', 'edit' => '#dns_records:edit'];
-
     /**
      * Create DNS record (permission needed: #dns_records:edit)
      * Create a new DNS record for a zone. See the record object definitions for required attributes for each record type

--- a/src/CloudFlare/Zone/Firewall/AccessRules.php
+++ b/src/CloudFlare/Zone/Firewall/AccessRules.php
@@ -4,7 +4,6 @@ namespace Cloudflare\Zone\Firewall;
 
 use Cloudflare\Api;
 use Cloudflare\Zone;
-use Cloudflare\Zone\Firewall;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Zone\Firewall;
  */
 class AccessRules extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone:read', 'edit' => '#zone:edit'];
-
     /**
      * List access rules (permission needed: #zone:read)
      * Search, sort, and filter IP/country access rule

--- a/src/CloudFlare/Zone/KeylessSSL.php
+++ b/src/CloudFlare/Zone/KeylessSSL.php
@@ -70,7 +70,7 @@ class KeylessSSL extends Api
      * @param int       $port            The keyless SSL port used to commmunicate between CloudFlare and the client's Keyless SSL server
      * @param bool|null $enabled         Whether or not the Keyless SSL is on or off
      */
-    public function update($zone_identifier, $identifier, $host, $name, $port, bool $enabled = null)
+    public function update($zone_identifier, $identifier, $host, $name, $port, $enabled = null)
     {
         $data = [
             'host'    => $host,

--- a/src/CloudFlare/Zone/KeylessSSL.php
+++ b/src/CloudFlare/Zone/KeylessSSL.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Zone;
  */
 class KeylessSSL extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#ssl:read', 'edit' => '#ssl:edit'];
-
     /**
      * Create a Keyless SSL configuration (permission needed: #ssl:edit)
      *

--- a/src/CloudFlare/Zone/Pagerules.php
+++ b/src/CloudFlare/Zone/Pagerules.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Zone;
  */
 class Pagerules extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone:read', 'edit' => '#zone:edit'];
-
     /**
      * Create a page rule [BETA] (permission needed: #zone:edit)
      *

--- a/src/CloudFlare/Zone/Plan.php
+++ b/src/CloudFlare/Zone/Plan.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Zone;
  */
 class Plan extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#billing:read', 'edit' => '#billing:edit'];
-
     /**
      * Available plans (permission needed: #billing:read)
      * List all plans the zone can subscribe to.

--- a/src/CloudFlare/Zone/Railgun.php
+++ b/src/CloudFlare/Zone/Railgun.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Zone;
  */
 class Railgun extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone_settings:read', 'edit' => '#zone_settings:edit'];
-
     /**
      * Get available Railguns (permission needed: #zone_settings:read)
      * A list of available Railguns the zone can use

--- a/src/CloudFlare/Zone/SSL.php
+++ b/src/CloudFlare/Zone/SSL.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Zone;
  */
 class SSL extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#ssl:read', 'edit' => '#ssl:edit'];
-
     /**
      * List SSL configurations (permission needed: #ssl:read)
      *

--- a/src/CloudFlare/Zone/SSL/Analyze.php
+++ b/src/CloudFlare/Zone/SSL/Analyze.php
@@ -4,7 +4,6 @@ namespace Cloudflare\Zone\SSL;
 
 use Cloudflare\Api;
 use Cloudflare\Zone;
-use Cloudflare\Zone\SSL;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Zone\SSL;
  */
 class Analyze extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#ssl:read', 'edit' => '#ssl:edit'];
-
     /**
      * Analyze Certificate (permission needed: #ssl:read)
      * Returns the set of hostnames, the signature algorithm, and the expiration date of the certificate.

--- a/src/CloudFlare/Zone/SSL/CertificatePacks.php
+++ b/src/CloudFlare/Zone/SSL/CertificatePacks.php
@@ -4,7 +4,6 @@ namespace Cloudflare\Zone\SSL;
 
 use Cloudflare\Api;
 use Cloudflare\Zone;
-use Cloudflare\Zone\SSL;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Zone\SSL;
  */
 class CertificatePacks extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#ssl:read', 'edit' => '#ssl:edit'];
-
     /**
      * List all certificate packs (permission needed: #ssl:read)
      * For a given zone, list all certificate packs

--- a/src/CloudFlare/Zone/Settings.php
+++ b/src/CloudFlare/Zone/Settings.php
@@ -3,7 +3,6 @@
 namespace Cloudflare\Zone;
 
 use Cloudflare\Api;
-use Cloudflare\Zone;
 
 /**
  * CloudFlare API wrapper
@@ -16,13 +15,6 @@ use Cloudflare\Zone;
  */
 class Settings extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone_settings:read', 'edit' => '#zone_settings:edit'];
-
     /**
      * Zone settings (permission needed: #zone_settings:read)
      * Available settings for your user in relation to a zone

--- a/src/CloudFlare/Zone/WAF/Packages.php
+++ b/src/CloudFlare/Zone/WAF/Packages.php
@@ -63,7 +63,7 @@ class Packages extends Api
      * @param string|null $sensitivity     The sensitivity of the firewall package.
      * @param string|null $action_mode     The default action that will be taken for rules under the firewall package.
      */
-    public function update(string $zone_identifier, $identifier, $sensitivity = null, $action_mode = null)
+    public function update($zone_identifier, $identifier, $sensitivity = null, $action_mode = null)
     {
         $data = [
             'sensitivity' => $sensitivity,

--- a/src/CloudFlare/Zone/WAF/Packages.php
+++ b/src/CloudFlare/Zone/WAF/Packages.php
@@ -4,7 +4,6 @@ namespace Cloudflare\Zone\WAF;
 
 use Cloudflare\Api;
 use Cloudflare\Zone;
-use Cloudflare\Zone\WAF;
 
 /**
  * CloudFlare API wrapper
@@ -17,13 +16,6 @@ use Cloudflare\Zone\WAF;
  */
 class Packages extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone:read', 'edit' => '#zone:edit'];
-
     /**
      * List firewall packages (permission needed: #zone:read)
      * Retrieve firewall packages for a zone

--- a/src/CloudFlare/Zone/WAF/Packages/Groups.php
+++ b/src/CloudFlare/Zone/WAF/Packages/Groups.php
@@ -5,7 +5,6 @@ namespace Cloudflare\Zone\WAF\Packages;
 use Cloudflare\Api;
 use Cloudflare\Zone;
 use Cloudflare\Zone\WAF;
-use Cloudflare\Zone\WAF\Packages;
 
 /**
  * CloudFlare API wrapper
@@ -18,13 +17,6 @@ use Cloudflare\Zone\WAF\Packages;
  */
 class Groups extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone:read', 'edit' => '#zone:edit'];
-
     /**
      * List rule groups (permission needed: #zone:read)
      * Search, list, and sort rule groups contained within a package

--- a/src/CloudFlare/Zone/WAF/Packages/Rules.php
+++ b/src/CloudFlare/Zone/WAF/Packages/Rules.php
@@ -5,7 +5,6 @@ namespace Cloudflare\Zone\WAF\Packages;
 use Cloudflare\Api;
 use Cloudflare\Zone;
 use Cloudflare\Zone\WAF;
-use Cloudflare\Zone\WAF\Packages;
 
 /**
  * CloudFlare API wrapper
@@ -18,13 +17,6 @@ use Cloudflare\Zone\WAF\Packages;
  */
 class Rules extends Api
 {
-    /**
-     * Default permissions level
-     *
-     * @var array
-     */
-    protected $permission_level = ['read' => '#zone:read', 'edit' => '#zone:edit'];
-
     /**
      * List rule (permission needed: #zone:read)
      * Search, list, and filter rules within a package

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Cloudflare\Api as Api;
+use Cloudflare\Exception\AuthenticationException;
 
 class ApiTest extends PHPUnit_Framework_TestCase
 {
@@ -102,5 +103,21 @@ class ApiTest extends PHPUnit_Framework_TestCase
         $result = $method->invoke($api, 'test');
 
         $this->assertEquals('get', $result->method);
+    }
+
+    public function testInvalidAuthenticationWithoutInformation()
+    {
+        self::setExpectedException(AuthenticationException::class);
+
+        $api = new Api();
+        $api->get('/bogus', []);
+    }
+
+    public function testInvalidAuthenticationWithInvalidParameters()
+    {
+        self::setExpectedException(AuthenticationException::class);
+
+        $api = new Api('foo.domain.tld', 'KEY');
+        $api->get('/bogus', []);
     }
 }


### PR DESCRIPTION
This PR is to remove the premature permission check which is occurs on every newly created `Api` instance. The reason to remove this check is to reduce the amount API requests and I personally found no use to this feature as Cloudflare will give that feedback as well on the original request (HTTP status code 401 and 403). 

Changes in this branch:
- Removed the old permission check implementation and moved the check on the actual request, where an exception will be thrown as soon you're not having the right permissions.
- Removed PHP7 strict type checking to keep the code compatible with PHP5.*
- Added `AuthenticationException` when the Authentication details are missing or invalid 
- Added `UnauthorizedException` when the user does not have the correct permissions to perform the API request.
- Fixed docblocks where the return type were missing