### PR TITLE
Ensure that the SSL/TLS certificate is checked when talking to CloudF…

### DIFF
--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -187,7 +187,7 @@ class Api
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_HEADER         => false,
             CURLOPT_TIMEOUT        => 30,
-            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYPEER => true,
             CURLOPT_FOLLOWLOCATION => true,
         ];
 


### PR DESCRIPTION
…lare

We prefer that our clients access our API over a verifiable connection.

Since having the option as it currently is, allows users credentials
to be stolen over the wire, if the attacked was actively evedropping
the connection