### PR TITLE
Add user agent to API calls.

### DIFF
--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -196,7 +196,7 @@ class Api
             $curl_options = array_replace($default_curl_options, $this->curl_options);
         }
 
-        $headers = ["X-Auth-Email: {$this->email}", "X-Auth-Key: {$this->auth_key}"];
+        $headers = ["X-Auth-Email: {$this->email}", "X-Auth-Key: {$this->auth_key}", "User-Agent: {__FILE__}"];
 
         $ch = curl_init();
         curl_setopt_array($ch, $curl_options);


### PR DESCRIPTION
Unfortunately a unnamed third party has used this API, in their
product, and due to issues in their code, have generated a very
large amount of requests to our system. While we were debugging
this, a hint of the user agent would have been really useful.

This PR adds a default UA to it, Because this API can be used
in many applications, I've made it the __FILE__ var, since
that will give us the best chance of getting in contact with
a possibly broken script vendor.