### PR TITLE
Update default data parameters for request methods

### DIFF
--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -92,12 +92,12 @@ class Api
     /**
      * API call method for sending requests using GET
      *
-     * @param string     $path Path of the endpoint
-     * @param array|null $data Data to be sent along with the request
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
      *
      * @return mixed
      */
-    public function get($path, array $data = null)
+    public function get($path, array $data = array())
     {
         return $this->request($path, $data, 'get');
     }
@@ -105,12 +105,12 @@ class Api
     /**
      * API call method for sending requests using POST
      *
-     * @param string     $path Path of the endpoint
-     * @param array|null $data Data to be sent along with the request
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
      *
      * @return mixed
      */
-    public function post($path, array $data = null)
+    public function post($path, array $data = array())
     {
         return $this->request($path, $data, 'post');
     }
@@ -118,12 +118,12 @@ class Api
     /**
      * API call method for sending requests using PUT
      *
-     * @param string     $path Path of the endpoint
-     * @param array|null $data Data to be sent along with the request
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
      *
      * @return mixed
      */
-    public function put($path, array $data = null)
+    public function put($path, array $data = array())
     {
         return $this->request($path, $data, 'put');
     }
@@ -131,12 +131,12 @@ class Api
     /**
      * API call method for sending requests using DELETE
      *
-     * @param string     $path Path of the endpoint
-     * @param array|null $data Data to be sent along with the request
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
      *
      * @return mixed
      */
-    public function delete($path, array $data = null)
+    public function delete($path, array $data = array())
     {
         return $this->request($path, $data, 'delete');
     }
@@ -144,12 +144,12 @@ class Api
     /**
      * API call method for sending requests using PATCH
      *
-     * @param string     $path Path of the endpoint
-     * @param array|null $data Data to be sent along with the request
+     * @param string $path Path of the endpoint
+     * @param array  $data Data to be sent along with the request
      *
      * @return mixed
      */
-    public function patch($path, array $data = null)
+    public function patch($path, array $data = array())
     {
         return $this->request($path, $data, 'patch');
     }
@@ -159,9 +159,9 @@ class Api
      *
      * API call method for sending requests using GET, POST, PUT, DELETE OR PATCH
      *
-     * @param string      $path   Path of the endpoint
-     * @param array|null  $data   Data to be sent along with the request
-     * @param string|null $method Type of method that should be used ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')
+     * @param string $path   Path of the endpoint
+     * @param array  $data   Data to be sent along with the request
+     * @param string $method Type of method that should be used ('GET', 'POST', 'PUT', 'DELETE', 'PATCH')
      *
      * @return mixed
      */

--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -97,7 +97,7 @@ class Api
      *
      * @return mixed
      */
-    public function get($path, array $data = array())
+    public function get($path, array $data = [])
     {
         return $this->request($path, $data, 'get');
     }
@@ -110,7 +110,7 @@ class Api
      *
      * @return mixed
      */
-    public function post($path, array $data = array())
+    public function post($path, array $data = [])
     {
         return $this->request($path, $data, 'post');
     }
@@ -123,7 +123,7 @@ class Api
      *
      * @return mixed
      */
-    public function put($path, array $data = array())
+    public function put($path, array $data = [])
     {
         return $this->request($path, $data, 'put');
     }
@@ -136,7 +136,7 @@ class Api
      *
      * @return mixed
      */
-    public function delete($path, array $data = array())
+    public function delete($path, array $data = [])
     {
         return $this->request($path, $data, 'delete');
     }
@@ -149,7 +149,7 @@ class Api
      *
      * @return mixed
      */
-    public function patch($path, array $data = array())
+    public function patch($path, array $data = [])
     {
         return $this->request($path, $data, 'patch');
     }
@@ -165,7 +165,7 @@ class Api
      *
      * @return mixed
      */
-    protected function request($path, array $data = array(), $method = 'get')
+    protected function request($path, array $data = [], $method = 'get')
     {
         if (!isset($this->email, $this->auth_key) || false === filter_var($this->email, FILTER_VALIDATE_EMAIL)) {
             throw new AuthenticationException('Authentication information must be provided');
@@ -194,8 +194,8 @@ class Api
 
         $user_agent = __FILE__;
         $headers = [
-            "X-Auth-Email: {$this->email}", 
-            "X-Auth-Key: {$this->auth_key}", 
+            "X-Auth-Email: {$this->email}",
+            "X-Auth-Key: {$this->auth_key}",
             "User-Agent: {$user_agent}",
             'Content-type: application/json',
         ];


### PR DESCRIPTION
v1.11.0 updated the default $data and $method parameters for the request method. The method parameters that call this method need to be updated to avoid exceptions being thrown.

This fixes the issue I opened at #73 