### PR TITLE
Removes array_filter callable to use array_filter default behaviour

### DIFF
--- a/src/CloudFlare/Api.php
+++ b/src/CloudFlare/Api.php
@@ -171,10 +171,8 @@ class Api
             throw new AuthenticationException('Authentication information must be provided');
         }
 
-        //Removes null entries
-        $data = array_filter($data, function ($val) {
-            return !is_null($val);
-        });
+        // Removes null entries
+        $data = array_filter($data);
 
         $url = 'https://api.cloudflare.com/client/v4/'.$path;
 


### PR DESCRIPTION
By default array_filter removes any null entries when filtering through an array, which means the callback is not needed.

Than being said, for those that don't know array_filters default behaviour the written code with the callback shows its intent a bit clearer along with the comment.